### PR TITLE
2451

### DIFF
--- a/apollo-client/pom.xml
+++ b/apollo-client/pom.xml
@@ -10,7 +10,19 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>apollo-client</artifactId>
 	<name>Apollo Client</name>
-	<properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
 		<java.version>1.7</java.version>
 		<github.path>${project.artifactId}</github.path>
 	</properties>

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/PropertiesCompatibleConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/PropertiesCompatibleConfigFile.java
@@ -1,7 +1,6 @@
 package com.ctrip.framework.apollo;
 
 import java.util.LinkedHashMap;
-import java.util.Properties;
 
 /**
  * Config files that are properties compatible, e.g. yaml

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/PropertiesCompatibleConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/PropertiesCompatibleConfigFile.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo;
 
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 /**
@@ -14,5 +15,5 @@ public interface PropertiesCompatibleConfigFile extends ConfigFile {
    *
    * @throws RuntimeException if the content could not be transformed to properties
    */
-  Properties asProperties();
+  LinkedHashMap asProperties();
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
@@ -23,12 +23,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
@@ -490,18 +485,18 @@ public abstract class AbstractConfig implements Config {
     return false;
   }
 
-  List<ConfigChange> calcPropertyChanges(String namespace, Properties previous,
-                                         Properties current) {
+  List<ConfigChange> calcPropertyChanges(String namespace, LinkedHashMap previous,
+                                         LinkedHashMap current) {
     if (previous == null) {
-      previous = new Properties();
+      previous = new LinkedHashMap();
     }
 
     if (current == null) {
-      current = new Properties();
+      current = new LinkedHashMap();
     }
 
-    Set<String> previousKeys = previous.stringPropertyNames();
-    Set<String> currentKeys = current.stringPropertyNames();
+    Set<String> previousKeys = previous.keySet();
+    Set<String> currentKeys = current.keySet();
 
     Set<String> commonKeys = Sets.intersection(previousKeys, currentKeys);
     Set<String> newKeys = Sets.difference(currentKeys, commonKeys);
@@ -510,18 +505,18 @@ public abstract class AbstractConfig implements Config {
     List<ConfigChange> changes = Lists.newArrayList();
 
     for (String newKey : newKeys) {
-      changes.add(new ConfigChange(namespace, newKey, null, current.getProperty(newKey),
+      changes.add(new ConfigChange(namespace, newKey, null, (String) current.get(newKey),
           PropertyChangeType.ADDED));
     }
 
     for (String removedKey : removedKeys) {
-      changes.add(new ConfigChange(namespace, removedKey, previous.getProperty(removedKey), null,
+      changes.add(new ConfigChange(namespace, removedKey, (String) previous.get(removedKey), null,
           PropertyChangeType.DELETED));
     }
 
     for (String commonKey : commonKeys) {
-      String previousValue = previous.getProperty(commonKey);
-      String currentValue = current.getProperty(commonKey);
+      String previousValue = (String) previous.get(commonKey);
+      String currentValue = (String) current.get(commonKey);
       if (Objects.equal(previousValue, currentValue)) {
         continue;
       }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
@@ -4,7 +4,6 @@ import com.ctrip.framework.apollo.enums.ConfigSourceType;
 
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
@@ -74,7 +73,7 @@ public abstract class AbstractConfigFile implements ConfigFile, RepositoryChange
     if (newProperties.equals(m_configProperties.get())) {
       return;
     }
-    Properties newConfigProperties = new Properties();
+    LinkedHashMap newConfigProperties = new LinkedHashMap();
     newConfigProperties.putAll(newProperties);
 
     String oldValue = getContent();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -28,7 +30,7 @@ public abstract class AbstractConfigFile implements ConfigFile, RepositoryChange
   private static ExecutorService m_executorService;
   protected final ConfigRepository m_configRepository;
   protected final String m_namespace;
-  protected final AtomicReference<Properties> m_configProperties;
+  protected final AtomicReference<LinkedHashMap> m_configProperties;
   private final List<ConfigFileChangeListener> m_listeners = Lists.newCopyOnWriteArrayList();
 
   private volatile ConfigSourceType m_sourceType = ConfigSourceType.NONE;
@@ -65,10 +67,10 @@ public abstract class AbstractConfigFile implements ConfigFile, RepositoryChange
     return m_namespace;
   }
 
-  protected abstract void update(Properties newProperties);
+  protected abstract void update(LinkedHashMap newProperties);
 
   @Override
-  public synchronized void onRepositoryChange(String namespace, Properties newProperties) {
+  public synchronized void onRepositoryChange(String namespace, LinkedHashMap newProperties) {
     if (newProperties.equals(m_configProperties.get())) {
       return;
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
 
@@ -44,7 +45,7 @@ public abstract class AbstractConfigRepository implements ConfigRepository {
     m_listeners.remove(listener);
   }
 
-  protected void fireRepositoryChange(String namespace, Properties newProperties) {
+  protected void fireRepositoryChange(String namespace, LinkedHashMap newProperties) {
     for (RepositoryChangeListener listener : m_listeners) {
       try {
         listener.onRepositoryChange(namespace, newProperties);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigRepository.java
@@ -2,7 +2,6 @@ package com.ctrip.framework.apollo.internals;
 
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Properties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 /**
@@ -11,7 +13,7 @@ public interface ConfigRepository {
    * Get the config from this repository.
    * @return config
    */
-  public Properties getConfig();
+  public LinkedHashMap getConfig();
 
   /**
    * Set the fallback repo for this repository.

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/ConfigRepository.java
@@ -3,7 +3,6 @@ package com.ctrip.framework.apollo.internals;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
 
 import java.util.LinkedHashMap;
-import java.util.Properties;
 
 /**
  * @author Jason Song(song_s@ctrip.com)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
@@ -109,7 +109,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
 
   private Set<String> stringPropertyNames(LinkedHashMap properties) {
     //jdk9以下版本Properties#enumerateStringProperties方法存在性能问题，keys() + get(k) 重复迭代, jdk9之后改为entrySet遍历.
-    Map<String, String> h = new HashMap<>();
+    Map<String, String> h = new LinkedHashMap<>();
     Set<Map.Entry> entrySet = properties.entrySet();
     for (Map.Entry e : entrySet) {
       Object k = e.getKey();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PlainTextConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PlainTextConfigFile.java
@@ -3,7 +3,6 @@ package com.ctrip.framework.apollo.internals;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 
 import java.util.LinkedHashMap;
-import java.util.Properties;
 
 /**
  * @author Jason Song(song_s@ctrip.com)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PlainTextConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PlainTextConfigFile.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.core.ConfigConsts;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 /**
@@ -17,7 +19,7 @@ public abstract class PlainTextConfigFile extends AbstractConfigFile {
     if (!this.hasContent()) {
       return null;
     }
-    return m_configProperties.get().getProperty(ConfigConsts.CONFIG_FILE_CONTENT_KEY);
+    return (String) m_configProperties.get().get(ConfigConsts.CONFIG_FILE_CONTENT_KEY);
   }
 
   @Override
@@ -29,7 +31,7 @@ public abstract class PlainTextConfigFile extends AbstractConfigFile {
   }
 
   @Override
-  protected void update(Properties newProperties) {
+  protected void update(LinkedHashMap newProperties) {
     m_configProperties.set(newProperties);
   }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesCompatibleFileConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesCompatibleFileConfigRepository.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import com.ctrip.framework.apollo.ConfigFileChangeListener;
@@ -11,7 +12,7 @@ import com.google.common.base.Preconditions;
 public class PropertiesCompatibleFileConfigRepository extends AbstractConfigRepository implements
     ConfigFileChangeListener {
   private final PropertiesCompatibleConfigFile configFile;
-  private volatile Properties cachedProperties;
+  private volatile LinkedHashMap cachedProperties;
 
   public PropertiesCompatibleFileConfigRepository(PropertiesCompatibleConfigFile configFile) {
     this.configFile = configFile;
@@ -21,7 +22,7 @@ public class PropertiesCompatibleFileConfigRepository extends AbstractConfigRepo
 
   @Override
   protected synchronized void sync() {
-    Properties current = configFile.asProperties();
+    LinkedHashMap current = configFile.asProperties();
 
     Preconditions.checkState(current != null, "PropertiesCompatibleConfigFile.asProperties should never return null");
 
@@ -32,7 +33,7 @@ public class PropertiesCompatibleFileConfigRepository extends AbstractConfigRepo
   }
 
   @Override
-  public Properties getConfig() {
+  public LinkedHashMap getConfig() {
     if (cachedProperties == null) {
       sync();
     }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/PropertiesConfigFile.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -25,7 +26,7 @@ public class PropertiesConfigFile extends AbstractConfigFile {
   }
 
   @Override
-  protected void update(Properties newProperties) {
+  protected void update(LinkedHashMap newProperties) {
     m_configProperties.set(newProperties);
     m_contentCache.set(null);
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
@@ -1,10 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -95,7 +93,7 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
   }
 
   @Override
-  public Properties getConfig() {
+  public LinkedHashMap getConfig() {
     if (m_configCache.get() == null) {
       this.sync();
     }
@@ -157,8 +155,8 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
     }
   }
 
-  private Properties transformApolloConfigToProperties(ApolloConfig apolloConfig) {
-    Properties result = new Properties();
+  private LinkedHashMap transformApolloConfigToProperties(ApolloConfig apolloConfig) {
+    LinkedHashMap result = new LinkedHashMap();
     result.putAll(apolloConfig.getConfigurations());
     return result;
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RepositoryChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RepositoryChangeListener.java
@@ -1,7 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
 import java.util.LinkedHashMap;
-import java.util.Properties;
 
 /**
  * @author Jason Song(song_s@ctrip.com)

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RepositoryChangeListener.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RepositoryChangeListener.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 /**
@@ -11,5 +12,5 @@ public interface RepositoryChangeListener {
    * @param namespace the namespace of this repository change
    * @param newProperties the properties after change
    */
-  public void onRepositoryChange(String namespace, Properties newProperties);
+  public void onRepositoryChange(String namespace, LinkedHashMap newProperties);
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/SimpleConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/SimpleConfig.java
@@ -1,11 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +21,7 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
   private static final Logger logger = LoggerFactory.getLogger(SimpleConfig.class);
   private final String m_namespace;
   private final ConfigRepository m_configRepository;
-  private volatile Properties m_configProperties;
+  private volatile LinkedHashMap m_configProperties;
   private volatile ConfigSourceType m_sourceType = ConfigSourceType.NONE;
 
   /**
@@ -59,7 +56,7 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
       logger.warn("Could not load config from Apollo, always return default value!");
       return defaultValue;
     }
-    return this.m_configProperties.getProperty(key, defaultValue);
+    return (String)this.m_configProperties.getOrDefault(key, defaultValue);
   }
 
   @Override
@@ -68,7 +65,7 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
       return Collections.emptySet();
     }
 
-    return m_configProperties.stringPropertyNames();
+    return m_configProperties.keySet();
   }
 
   @Override
@@ -77,11 +74,11 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
   }
 
   @Override
-  public synchronized void onRepositoryChange(String namespace, Properties newProperties) {
+  public synchronized void onRepositoryChange(String namespace, LinkedHashMap newProperties) {
     if (newProperties.equals(m_configProperties)) {
       return;
     }
-    Properties newConfigProperties = new Properties();
+    LinkedHashMap newConfigProperties = new LinkedHashMap();
     newConfigProperties.putAll(newProperties);
 
     List<ConfigChange> changes = calcPropertyChanges(namespace, m_configProperties, newConfigProperties);
@@ -101,7 +98,7 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
     Tracer.logEvent("Apollo.Client.ConfigChanges", m_namespace);
   }
 
-  private void updateConfig(Properties newConfigProperties, ConfigSourceType sourceType) {
+  private void updateConfig(LinkedHashMap newConfigProperties, ConfigSourceType sourceType) {
     m_configProperties = newConfigProperties;
     m_sourceType = sourceType;
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/YamlConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/YamlConfigFile.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.util.ExceptionUtil;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -18,7 +20,7 @@ import com.ctrip.framework.apollo.util.yaml.YamlParser;
  */
 public class YamlConfigFile extends PlainTextConfigFile implements PropertiesCompatibleConfigFile {
   private static final Logger logger = LoggerFactory.getLogger(YamlConfigFile.class);
-  private volatile Properties cachedProperties;
+  private volatile LinkedHashMap cachedProperties;
 
   public YamlConfigFile(String namespace, ConfigRepository configRepository) {
     super(namespace, configRepository);
@@ -31,13 +33,13 @@ public class YamlConfigFile extends PlainTextConfigFile implements PropertiesCom
   }
 
   @Override
-  protected void update(Properties newProperties) {
+  protected void update(LinkedHashMap newProperties) {
     super.update(newProperties);
     tryTransformToProperties();
   }
 
   @Override
-  public Properties asProperties() {
+  public LinkedHashMap asProperties() {
     if (cachedProperties == null) {
       transformToProperties();
     }
@@ -59,9 +61,9 @@ public class YamlConfigFile extends PlainTextConfigFile implements PropertiesCom
     cachedProperties = toProperties();
   }
 
-  private Properties toProperties() {
+  private LinkedHashMap toProperties() {
     if (!this.hasContent()) {
-      return new Properties();
+      return new LinkedHashMap();
     }
 
     try {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spi/DefaultConfigFactory.java
@@ -2,8 +2,7 @@ package com.ctrip.framework.apollo.spi;
 
 import com.ctrip.framework.apollo.ConfigService;
 import com.ctrip.framework.apollo.PropertiesCompatibleConfigFile;
-import com.ctrip.framework.apollo.internals.PropertiesCompatibleFileConfigRepository;
-import com.ctrip.framework.apollo.internals.TxtConfigFile;
+import com.ctrip.framework.apollo.internals.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,15 +10,6 @@ import com.ctrip.framework.apollo.Config;
 import com.ctrip.framework.apollo.ConfigFile;
 import com.ctrip.framework.apollo.build.ApolloInjector;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
-import com.ctrip.framework.apollo.internals.ConfigRepository;
-import com.ctrip.framework.apollo.internals.DefaultConfig;
-import com.ctrip.framework.apollo.internals.JsonConfigFile;
-import com.ctrip.framework.apollo.internals.LocalFileConfigRepository;
-import com.ctrip.framework.apollo.internals.PropertiesConfigFile;
-import com.ctrip.framework.apollo.internals.RemoteConfigRepository;
-import com.ctrip.framework.apollo.internals.XmlConfigFile;
-import com.ctrip.framework.apollo.internals.YamlConfigFile;
-import com.ctrip.framework.apollo.internals.YmlConfigFile;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 
 /**

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -103,9 +103,6 @@ public class ApolloApplicationContextInitializer implements
       Config config = ConfigService.getConfig(namespace);
 
       composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
-      if(namespace.endsWith(".yml")){
-
-      }
 
     }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/boot/ApolloApplicationContextInitializer.java
@@ -103,6 +103,10 @@ public class ApolloApplicationContextInitializer implements
       Config config = ConfigService.getConfig(namespace);
 
       composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
+      if(namespace.endsWith(".yml")){
+
+      }
+
     }
 
     environment.getPropertySources().addFirst(composite);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -74,9 +74,14 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
     while (iterator.hasNext()) {
       int order = iterator.next();
       for (String namespace : NAMESPACE_NAMES.get(order)) {
-        Config config = ConfigService.getConfig(namespace);
+        if(namespace.endsWith(".yml")){
 
-        composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
+        }
+        else {
+          Config config = ConfigService.getConfig(namespace);
+
+          composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
+        }
       }
     }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/spring/config/PropertySourcesProcessor.java
@@ -74,14 +74,10 @@ public class PropertySourcesProcessor implements BeanFactoryPostProcessor, Envir
     while (iterator.hasNext()) {
       int order = iterator.next();
       for (String namespace : NAMESPACE_NAMES.get(order)) {
-        if(namespace.endsWith(".yml")){
-
-        }
-        else {
           Config config = ConfigService.getConfig(namespace);
 
           composite.addPropertySource(configPropertySourceFactory.getConfigPropertySource(namespace, config));
-        }
+
       }
     }
 

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -33,7 +32,7 @@ public class YamlParser {
     final LinkedHashMap result = new LinkedHashMap();
     process(new MatchCallback() {
       @Override
-      public void process(Properties properties, Map<String, Object> map) {
+      public void process(LinkedHashMap properties, Map<String, Object> map) {
         result.putAll(properties);
       }
     }, yaml, yamlContent);
@@ -91,7 +90,7 @@ public class YamlParser {
   }
 
   private boolean process(Map<String, Object> map, MatchCallback callback) {
-    Properties properties = new Properties();
+    LinkedHashMap properties = new LinkedHashMap();
     properties.putAll(getFlattenedMap(map));
 
     if (logger.isDebugEnabled()) {
@@ -140,7 +139,7 @@ public class YamlParser {
   }
 
   private interface MatchCallback {
-    void process(Properties properties, Map<String, Object> map);
+    void process(LinkedHashMap properties, Map<String, Object> map);
   }
 
   private static class StrictMapAppenderConstructor extends Constructor {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
@@ -28,9 +28,9 @@ public class YamlParser {
   /**
    * Transform yaml content to properties
    */
-  public Properties yamlToProperties(String yamlContent) {
+  public LinkedHashMap yamlToProperties(String yamlContent) {
     Yaml yaml = createYaml();
-    final Properties result = new Properties();
+    final LinkedHashMap result = new LinkedHashMap();
     process(new MatchCallback() {
       @Override
       public void process(Properties properties, Map<String, Object> map) {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/DefaultConfigManagerTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/DefaultConfigManagerTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import java.util.Set;
 
@@ -118,7 +120,7 @@ public class DefaultConfigManagerTest {
           return new AbstractConfigFile(namespace, someConfigRepository) {
 
             @Override
-            protected void update(Properties newProperties) {
+            protected void update(LinkedHashMap newProperties) {
 
             }
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/DefaultConfigTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/DefaultConfigTest.java
@@ -13,13 +13,7 @@ import com.ctrip.framework.apollo.enums.ConfigSourceType;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.io.File;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Function;
@@ -50,7 +44,7 @@ public class DefaultConfigTest {
   private File someResourceDir;
   private String someNamespace;
   private ConfigRepository configRepository;
-  private Properties someProperties;
+  private LinkedHashMap someProperties;
   private ConfigSourceType someSourceType;
 
   @Before
@@ -97,9 +91,9 @@ public class DefaultConfigTest {
     System.setProperty(someKey, someSystemPropertyValue);
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someKey, someLocalFileValue);
-    someProperties.setProperty(anotherKey, someLocalFileValue);
+    someProperties = new LinkedHashMap<>();
+    someProperties.put(someKey, someLocalFileValue);
+    someProperties.put(anotherKey, someLocalFileValue);
     when(configRepository.getConfig()).thenReturn(someProperties);
     someSourceType = ConfigSourceType.LOCAL;
     when(configRepository.getSourceType()).thenReturn(someSourceType);
@@ -140,9 +134,9 @@ public class DefaultConfigTest {
     Integer someDefaultValue = -1;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -160,8 +154,8 @@ public class DefaultConfigTest {
     Integer someDefaultValue = -1;
 
     //set up config repo
-    someProperties = mock(Properties.class);
-    when(someProperties.getProperty(someKey)).thenReturn(String.valueOf(someValue));
+    someProperties = mock(LinkedHashMap.class);
+    when(someProperties.get(someKey)).thenReturn(String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -171,7 +165,7 @@ public class DefaultConfigTest {
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
 
-    verify(someProperties, times(1)).getProperty(someKey);
+    verify(someProperties, times(1)).get(someKey);
   }
 
   @Test
@@ -183,8 +177,8 @@ public class DefaultConfigTest {
     Integer someDefaultValue = -1;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -192,8 +186,8 @@ public class DefaultConfigTest {
 
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(someKey, String.valueOf(anotherValue));
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(someKey, String.valueOf(anotherValue));
 
     defaultConfig.onRepositoryChange(someNamespace, anotherProperties);
 
@@ -213,9 +207,9 @@ public class DefaultConfigTest {
     MockInjector.setInstance(ConfigUtil.class, new MockConfigUtilWithSmallCache());
 
     //set up config repo
-    someProperties = mock(Properties.class);
-    when(someProperties.getProperty(someKey)).thenReturn(String.valueOf(someValue));
-    when(someProperties.getProperty(anotherKey)).thenReturn(String.valueOf(anotherValue));
+    someProperties = mock(LinkedHashMap.class);
+    when(someProperties.get(someKey)).thenReturn(String.valueOf(someValue));
+    when(someProperties.get(anotherKey)).thenReturn(String.valueOf(anotherValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -224,16 +218,16 @@ public class DefaultConfigTest {
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
 
-    verify(someProperties, times(1)).getProperty(someKey);
+    verify(someProperties, times(1)).get(someKey);
 
     assertEquals(anotherValue, defaultConfig.getIntProperty(anotherKey, someDefaultValue));
     assertEquals(anotherValue, defaultConfig.getIntProperty(anotherKey, someDefaultValue));
 
-    verify(someProperties, times(1)).getProperty(anotherKey);
+    verify(someProperties, times(1)).get(anotherKey);
 
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
 
-    verify(someProperties, times(2)).getProperty(someKey);
+    verify(someProperties, times(2)).get(someKey);
   }
 
   @Test
@@ -246,8 +240,8 @@ public class DefaultConfigTest {
     MockInjector.setInstance(ConfigUtil.class, new MockConfigUtilWithShortExpireTime());
 
     //set up config repo
-    someProperties = mock(Properties.class);
-    when(someProperties.getProperty(someKey)).thenReturn(String.valueOf(someValue));
+    someProperties = mock(LinkedHashMap.class);
+    when(someProperties.get(someKey)).thenReturn(String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -256,14 +250,14 @@ public class DefaultConfigTest {
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
 
-    verify(someProperties, times(1)).getProperty(someKey);
+    verify(someProperties, times(1)).get(someKey);
 
     TimeUnit.MILLISECONDS.sleep(50);
 
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
     assertEquals(someValue, defaultConfig.getIntProperty(someKey, someDefaultValue));
 
-    verify(someProperties, times(2)).getProperty(someKey);
+    verify(someProperties, times(2)).get(someKey);
   }
 
   @Test
@@ -277,9 +271,9 @@ public class DefaultConfigTest {
     Long someDefaultValue = -1l;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -300,9 +294,9 @@ public class DefaultConfigTest {
     Short someDefaultValue = -1;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -323,9 +317,9 @@ public class DefaultConfigTest {
     Float someDefaultValue = -1f;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -346,9 +340,9 @@ public class DefaultConfigTest {
     Double someDefaultValue = -1d;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -369,9 +363,9 @@ public class DefaultConfigTest {
     Byte someDefaultValue = -1;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -392,9 +386,9 @@ public class DefaultConfigTest {
     Boolean someDefaultValue = false;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someStringKey, someStringValue);
-    someProperties.setProperty(someKey, String.valueOf(someValue));
+    someProperties = new LinkedHashMap();
+    someProperties.put(someStringKey, someStringValue);
+    someProperties.put(someKey, String.valueOf(someValue));
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -416,8 +410,8 @@ public class DefaultConfigTest {
     String[] someDefaultValue = new String[]{"1", "2"};
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someKey, someValue);
+    someProperties = new LinkedHashMap();
+    someProperties.put(someKey, someValue);
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -440,8 +434,8 @@ public class DefaultConfigTest {
     String[] someDefaultValue = new String[]{"1", "2"};
 
     //set up config repo
-    someProperties = mock(Properties.class);
-    when(someProperties.getProperty(someKey)).thenReturn(someValue);
+    someProperties = mock(LinkedHashMap.class);
+    when(someProperties.get(someKey)).thenReturn(someValue);
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -450,14 +444,14 @@ public class DefaultConfigTest {
     assertArrayEquals(values, defaultConfig.getArrayProperty(someKey, someDelimiter, someDefaultValue));
     assertArrayEquals(values, defaultConfig.getArrayProperty(someKey, someDelimiter, someDefaultValue));
 
-    verify(someProperties, times(1)).getProperty(someKey);
+    verify(someProperties, times(1)).get(someKey);
 
     assertArrayEquals(someDefaultValue, defaultConfig.getArrayProperty(someKey, someInvalidDelimiter,
         someDefaultValue));
     assertArrayEquals(someDefaultValue, defaultConfig.getArrayProperty(someKey, someInvalidDelimiter,
         someDefaultValue));
 
-    verify(someProperties, times(3)).getProperty(someKey);
+    verify(someProperties, times(3)).get(someKey);
   }
 
   @Test
@@ -473,12 +467,12 @@ public class DefaultConfigTest {
     String[] someDefaultValue = new String[]{"1", "2"};
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someKey, someValue);
+    someProperties = new LinkedHashMap();
+    someProperties.put(someKey, someValue);
     when(configRepository.getConfig()).thenReturn(someProperties);
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(someKey, anotherValue);
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(someKey, anotherValue);
 
     DefaultConfig defaultConfig =
         new DefaultConfig(someNamespace, configRepository);
@@ -499,11 +493,11 @@ public class DefaultConfigTest {
     Date longDate = assembleDate(2016, 9, 28, 15, 10, 10, 123);
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty("shortDateProperty", "2016-09-28");
-    someProperties.setProperty("mediumDateProperty", "2016-09-28 15:10:10");
-    someProperties.setProperty("longDateProperty", "2016-09-28 15:10:10.123");
-    someProperties.setProperty("stringProperty", "someString");
+    someProperties = new LinkedHashMap();
+    someProperties.put("shortDateProperty", "2016-09-28");
+    someProperties.put("mediumDateProperty", "2016-09-28 15:10:10");
+    someProperties.put("longDateProperty", "2016-09-28 15:10:10.123");
+    someProperties.put("stringProperty", "someString");
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -529,11 +523,11 @@ public class DefaultConfigTest {
     Date longDate = assembleDate(2016, 9, 28, 15, 10, 10, 123);
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty("shortDateProperty", "2016-09-28");
-    someProperties.setProperty("mediumDateProperty", "2016-09-28 15:10:10");
-    someProperties.setProperty("longDateProperty", "2016-09-28 15:10:10.123");
-    someProperties.setProperty("stringProperty", "someString");
+    someProperties = new LinkedHashMap();
+    someProperties.put("shortDateProperty", "2016-09-28");
+    someProperties.put("mediumDateProperty", "2016-09-28 15:10:10");
+    someProperties.put("longDateProperty", "2016-09-28 15:10:10.123");
+    someProperties.put("stringProperty", "someString");
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -550,9 +544,9 @@ public class DefaultConfigTest {
     SomeEnum someDefaultValue = SomeEnum.defaultValue;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty("enumProperty", "someValue");
-    someProperties.setProperty("stringProperty", "someString");
+    someProperties = new LinkedHashMap();
+    someProperties.put("enumProperty", "someValue");
+    someProperties.put("stringProperty", "someString");
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -568,9 +562,9 @@ public class DefaultConfigTest {
     long result = 2 * 24 * 3600 * 1000 + 3 * 3600 * 1000 + 4 * 60 * 1000 + 5 * 1000 + 123;
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty("durationProperty", "2D3H4m5S123ms");
-    someProperties.setProperty("stringProperty", "someString");
+    someProperties = new LinkedHashMap();
+    someProperties.put("durationProperty", "2D3H4m5S123ms");
+    someProperties.put("stringProperty", "someString");
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -599,7 +593,7 @@ public class DefaultConfigTest {
     System.setProperty(someKey, someSystemPropertyValue);
 
     //set up config repo
-    someProperties = new Properties();
+    someProperties = new LinkedHashMap();
     someProperties.putAll(ImmutableMap
         .of(someKey, someLocalFileValue, anotherKey, someLocalFileValue, keyToBeDeleted,
             keyToBeDeletedValue, yetAnotherKey, yetAnotherValue));
@@ -626,7 +620,7 @@ public class DefaultConfigTest {
 
     defaultConfig.addChangeListener(someListener);
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
     String someKeyNewValue = "new-some-value";
     String anotherKeyNewValue = "another-new-value";
     String newKey = "newKey";
@@ -782,9 +776,9 @@ public class DefaultConfigTest {
     String someValuePrefix = "someValue";
 
     //set up config repo
-    someProperties = new Properties();
+    someProperties = new LinkedHashMap();
     for (int i = 0; i < 10; i++) {
-      someProperties.setProperty(someKeyPrefix + i, someValuePrefix + i);
+      someProperties.put(someKeyPrefix + i, someValuePrefix + i);
     }
 
     when(configRepository.getConfig()).thenReturn(someProperties);
@@ -795,7 +789,7 @@ public class DefaultConfigTest {
     Set<String> propertyNames = defaultConfig.getPropertyNames();
 
     assertEquals(10, propertyNames.size());
-    assertEquals(someProperties.stringPropertyNames(), propertyNames);
+    assertEquals(someProperties.keySet(), propertyNames);
   }
 
   @Test
@@ -818,8 +812,8 @@ public class DefaultConfigTest {
     String someNullKey = "someNullKey";
 
     //set up config repo
-    someProperties = new Properties();
-    someProperties.setProperty(someKey, someValue);
+    someProperties = new LinkedHashMap();
+    someProperties.put(someKey, someValue);
     when(configRepository.getConfig()).thenReturn(someProperties);
 
     DefaultConfig defaultConfig =
@@ -856,8 +850,8 @@ public class DefaultConfigTest {
     assertEquals(ConfigSourceType.NONE, defaultConfig.getSourceType());
     assertEquals(someDefaultValue, defaultConfig.getProperty(someKey, someDefaultValue));
 
-    someProperties = new Properties();
-    someProperties.setProperty(someKey, someValue);
+    someProperties = new LinkedHashMap();
+    someProperties.put(someKey, someValue);
 
     when(configRepository.getSourceType()).thenReturn(someSourceType);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/JsonConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/JsonConfigFileTest.java
@@ -1,129 +1,132 @@
 package com.ctrip.framework.apollo.internals;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import java.util.LinkedHashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.LinkedHashMap;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
-
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JsonConfigFileTest {
-    private String someNamespace;
-    @Mock
-    private ConfigRepository configRepository;
 
-    private ConfigSourceType someSourceType;
+  private String someNamespace;
+  @Mock
+  private ConfigRepository configRepository;
 
-    @Before
-    public void setUp() throws Exception {
-        someNamespace = "someName";
-    }
+  private ConfigSourceType someSourceType;
 
-    @Test
-    public void testWhenHasContent() throws Exception {
-        LinkedHashMap someProperties = new LinkedHashMap();
-        String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
-        String someValue = "someValue";
-        someProperties.put(key, someValue);
+  @Before
+  public void setUp() throws Exception {
+    someNamespace = "someName";
+  }
 
-        someSourceType = ConfigSourceType.LOCAL;
+  @Test
+  public void testWhenHasContent() throws Exception {
+    LinkedHashMap someProperties = new LinkedHashMap();
+    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+    String someValue = "someValue";
+    someProperties.put(key, someValue);
 
-        when(configRepository.getConfig()).thenReturn(someProperties);
-        when(configRepository.getSourceType()).thenReturn(someSourceType);
+    someSourceType = ConfigSourceType.LOCAL;
 
-        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+    when(configRepository.getConfig()).thenReturn(someProperties);
+    when(configRepository.getSourceType()).thenReturn(someSourceType);
 
-        assertEquals(ConfigFileFormat.JSON, configFile.getConfigFileFormat());
-        assertEquals(someNamespace, configFile.getNamespace());
-        assertTrue(configFile.hasContent());
-        assertEquals(someValue, configFile.getContent());
-        assertEquals(someSourceType, configFile.getSourceType());
-    }
+    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    @Test
-    public void testWhenHasNoContent() throws Exception {
-        when(configRepository.getConfig()).thenReturn(null);
+    assertEquals(ConfigFileFormat.JSON, configFile.getConfigFileFormat());
+    assertEquals(someNamespace, configFile.getNamespace());
+    assertTrue(configFile.hasContent());
+    assertEquals(someValue, configFile.getContent());
+    assertEquals(someSourceType, configFile.getSourceType());
+  }
 
-        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+  @Test
+  public void testWhenHasNoContent() throws Exception {
+    when(configRepository.getConfig()).thenReturn(null);
 
-        assertFalse(configFile.hasContent());
-        assertNull(configFile.getContent());
-    }
+    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    @Test
-    public void testWhenConfigRepositoryHasError() throws Exception {
-        when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
+    assertFalse(configFile.hasContent());
+    assertNull(configFile.getContent());
+  }
 
-        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+  @Test
+  public void testWhenConfigRepositoryHasError() throws Exception {
+    when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
 
-        assertFalse(configFile.hasContent());
-        assertNull(configFile.getContent());
-        assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
-    }
+    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    @Test
-    public void testOnRepositoryChange() throws Exception {
-        LinkedHashMap someProperties = new LinkedHashMap();
-        String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
-        String someValue = "someValue";
-        String anotherValue = "anotherValue";
-        someProperties.put(key, someValue);
+    assertFalse(configFile.hasContent());
+    assertNull(configFile.getContent());
+    assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
+  }
 
-        someSourceType = ConfigSourceType.LOCAL;
+  @Test
+  public void testOnRepositoryChange() throws Exception {
+    LinkedHashMap someProperties = new LinkedHashMap();
+    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+    String someValue = "someValue";
+    String anotherValue = "anotherValue";
+    someProperties.put(key, someValue);
 
-        when(configRepository.getConfig()).thenReturn(someProperties);
-        when(configRepository.getSourceType()).thenReturn(someSourceType);
+    someSourceType = ConfigSourceType.LOCAL;
 
-        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+    when(configRepository.getConfig()).thenReturn(someProperties);
+    when(configRepository.getSourceType()).thenReturn(someSourceType);
 
-        assertEquals(someValue, configFile.getContent());
-        assertEquals(someSourceType, configFile.getSourceType());
+    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-        LinkedHashMap anotherProperties = new LinkedHashMap();
-        anotherProperties.put(key, anotherValue);
+    assertEquals(someValue, configFile.getContent());
+    assertEquals(someSourceType, configFile.getSourceType());
 
-        ConfigSourceType anotherSourceType = ConfigSourceType.REMOTE;
-        when(configRepository.getSourceType()).thenReturn(anotherSourceType);
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(key, anotherValue);
 
-        configFile.onRepositoryChange(someNamespace, anotherProperties);
+    ConfigSourceType anotherSourceType = ConfigSourceType.REMOTE;
+    when(configRepository.getSourceType()).thenReturn(anotherSourceType);
 
-        assertEquals(anotherValue, configFile.getContent());
-        assertEquals(anotherSourceType, configFile.getSourceType());
-    }
+    configFile.onRepositoryChange(someNamespace, anotherProperties);
 
-    @Test
-    public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
-        LinkedHashMap someProperties = new LinkedHashMap();
-        String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
-        String someValue = "someValue";
-        someProperties.put(key, someValue);
+    assertEquals(anotherValue, configFile.getContent());
+    assertEquals(anotherSourceType, configFile.getSourceType());
+  }
 
-        someSourceType = ConfigSourceType.LOCAL;
+  @Test
+  public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
+    LinkedHashMap someProperties = new LinkedHashMap();
+    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+    String someValue = "someValue";
+    someProperties.put(key, someValue);
 
-        when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
-        when(configRepository.getSourceType()).thenReturn(someSourceType);
+    someSourceType = ConfigSourceType.LOCAL;
 
-        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+    when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
+    when(configRepository.getSourceType()).thenReturn(someSourceType);
 
-        assertFalse(configFile.hasContent());
-        assertNull(configFile.getContent());
-        assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
+    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-        configFile.onRepositoryChange(someNamespace, someProperties);
+    assertFalse(configFile.hasContent());
+    assertNull(configFile.getContent());
+    assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
 
-        assertTrue(configFile.hasContent());
-        assertEquals(someValue, configFile.getContent());
-        assertEquals(someSourceType, configFile.getSourceType());
-    }
+    configFile.onRepositoryChange(someNamespace, someProperties);
+
+    assertTrue(configFile.hasContent());
+    assertEquals(someValue, configFile.getContent());
+    assertEquals(someSourceType, configFile.getSourceType());
+  }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/JsonConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/JsonConfigFileTest.java
@@ -1,133 +1,129 @@
 package com.ctrip.framework.apollo.internals;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
+import com.ctrip.framework.apollo.core.ConfigConsts;
+import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
-import java.util.Properties;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.ctrip.framework.apollo.core.ConfigConsts;
-import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
  */
 @RunWith(MockitoJUnitRunner.class)
 public class JsonConfigFileTest {
-  private String someNamespace;
-  @Mock
-  private ConfigRepository configRepository;
+    private String someNamespace;
+    @Mock
+    private ConfigRepository configRepository;
 
-  private ConfigSourceType someSourceType;
+    private ConfigSourceType someSourceType;
 
-  @Before
-  public void setUp() throws Exception {
-    someNamespace = "someName";
-  }
+    @Before
+    public void setUp() throws Exception {
+        someNamespace = "someName";
+    }
 
-  @Test
-  public void testWhenHasContent() throws Exception {
-    Properties someProperties = new Properties();
-    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
-    String someValue = "someValue";
-    someProperties.setProperty(key, someValue);
+    @Test
+    public void testWhenHasContent() throws Exception {
+        LinkedHashMap someProperties = new LinkedHashMap();
+        String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+        String someValue = "someValue";
+        someProperties.put(key, someValue);
 
-    someSourceType = ConfigSourceType.LOCAL;
+        someSourceType = ConfigSourceType.LOCAL;
 
-    when(configRepository.getConfig()).thenReturn(someProperties);
-    when(configRepository.getSourceType()).thenReturn(someSourceType);
+        when(configRepository.getConfig()).thenReturn(someProperties);
+        when(configRepository.getSourceType()).thenReturn(someSourceType);
 
-    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    assertEquals(ConfigFileFormat.JSON, configFile.getConfigFileFormat());
-    assertEquals(someNamespace, configFile.getNamespace());
-    assertTrue(configFile.hasContent());
-    assertEquals(someValue, configFile.getContent());
-    assertEquals(someSourceType, configFile.getSourceType());
-  }
+        assertEquals(ConfigFileFormat.JSON, configFile.getConfigFileFormat());
+        assertEquals(someNamespace, configFile.getNamespace());
+        assertTrue(configFile.hasContent());
+        assertEquals(someValue, configFile.getContent());
+        assertEquals(someSourceType, configFile.getSourceType());
+    }
 
-  @Test
-  public void testWhenHasNoContent() throws Exception {
-    when(configRepository.getConfig()).thenReturn(null);
+    @Test
+    public void testWhenHasNoContent() throws Exception {
+        when(configRepository.getConfig()).thenReturn(null);
 
-    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    assertFalse(configFile.hasContent());
-    assertNull(configFile.getContent());
-  }
+        assertFalse(configFile.hasContent());
+        assertNull(configFile.getContent());
+    }
 
-  @Test
-  public void testWhenConfigRepositoryHasError() throws Exception {
-    when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
+    @Test
+    public void testWhenConfigRepositoryHasError() throws Exception {
+        when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
 
-    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    assertFalse(configFile.hasContent());
-    assertNull(configFile.getContent());
-    assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
-  }
+        assertFalse(configFile.hasContent());
+        assertNull(configFile.getContent());
+        assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
+    }
 
-  @Test
-  public void testOnRepositoryChange() throws Exception {
-    Properties someProperties = new Properties();
-    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
-    String someValue = "someValue";
-    String anotherValue = "anotherValue";
-    someProperties.setProperty(key, someValue);
+    @Test
+    public void testOnRepositoryChange() throws Exception {
+        LinkedHashMap someProperties = new LinkedHashMap();
+        String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+        String someValue = "someValue";
+        String anotherValue = "anotherValue";
+        someProperties.put(key, someValue);
 
-    someSourceType = ConfigSourceType.LOCAL;
+        someSourceType = ConfigSourceType.LOCAL;
 
-    when(configRepository.getConfig()).thenReturn(someProperties);
-    when(configRepository.getSourceType()).thenReturn(someSourceType);
+        when(configRepository.getConfig()).thenReturn(someProperties);
+        when(configRepository.getSourceType()).thenReturn(someSourceType);
 
-    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    assertEquals(someValue, configFile.getContent());
-    assertEquals(someSourceType, configFile.getSourceType());
+        assertEquals(someValue, configFile.getContent());
+        assertEquals(someSourceType, configFile.getSourceType());
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(key, anotherValue);
+        LinkedHashMap anotherProperties = new LinkedHashMap();
+        anotherProperties.put(key, anotherValue);
 
-    ConfigSourceType anotherSourceType = ConfigSourceType.REMOTE;
-    when(configRepository.getSourceType()).thenReturn(anotherSourceType);
+        ConfigSourceType anotherSourceType = ConfigSourceType.REMOTE;
+        when(configRepository.getSourceType()).thenReturn(anotherSourceType);
 
-    configFile.onRepositoryChange(someNamespace, anotherProperties);
+        configFile.onRepositoryChange(someNamespace, anotherProperties);
 
-    assertEquals(anotherValue, configFile.getContent());
-    assertEquals(anotherSourceType, configFile.getSourceType());
-  }
+        assertEquals(anotherValue, configFile.getContent());
+        assertEquals(anotherSourceType, configFile.getSourceType());
+    }
 
-  @Test
-  public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
-    Properties someProperties = new Properties();
-    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
-    String someValue = "someValue";
-    someProperties.setProperty(key, someValue);
+    @Test
+    public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
+        LinkedHashMap someProperties = new LinkedHashMap();
+        String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+        String someValue = "someValue";
+        someProperties.put(key, someValue);
 
-    someSourceType = ConfigSourceType.LOCAL;
+        someSourceType = ConfigSourceType.LOCAL;
 
-    when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
-    when(configRepository.getSourceType()).thenReturn(someSourceType);
+        when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
+        when(configRepository.getSourceType()).thenReturn(someSourceType);
 
-    JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
+        JsonConfigFile configFile = new JsonConfigFile(someNamespace, configRepository);
 
-    assertFalse(configFile.hasContent());
-    assertNull(configFile.getContent());
-    assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
+        assertFalse(configFile.hasContent());
+        assertNull(configFile.getContent());
+        assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
 
-    configFile.onRepositoryChange(someNamespace, someProperties);
+        configFile.onRepositoryChange(someNamespace, someProperties);
 
-    assertTrue(configFile.hasContent());
-    assertEquals(someValue, configFile.getContent());
-    assertEquals(someSourceType, configFile.getSourceType());
-  }
+        assertTrue(configFile.hasContent());
+        assertEquals(someValue, configFile.getContent());
+        assertEquals(someSourceType, configFile.getSourceType());
+    }
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/PropertiesCompatibleFileConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/PropertiesCompatibleFileConfigRepositoryTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.when;
 import com.ctrip.framework.apollo.PropertiesCompatibleConfigFile;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
 import com.ctrip.framework.apollo.model.ConfigFileChangeEvent;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +28,7 @@ public class PropertiesCompatibleFileConfigRepositoryTest {
   private String someNamespaceName;
 
   @Mock
-  private Properties someProperties;
+  private LinkedHashMap someProperties;
 
   @Before
   public void setUp() throws Exception {
@@ -65,7 +67,7 @@ public class PropertiesCompatibleFileConfigRepositoryTest {
     // recovered
     reset(configFile);
 
-    Properties someProperties = mock(Properties.class);
+    LinkedHashMap someProperties = mock(LinkedHashMap.class);
 
     when(configFile.asProperties()).thenReturn(someProperties);
 
@@ -96,7 +98,7 @@ public class PropertiesCompatibleFileConfigRepositoryTest {
 
   @Test
   public void testOnChange() throws Exception {
-    Properties anotherProperties = mock(Properties.class);
+    LinkedHashMap anotherProperties = mock(LinkedHashMap.class);
     ConfigFileChangeEvent someChangeEvent = mock(ConfigFileChangeEvent.class);
 
     RepositoryChangeListener someListener = mock(RepositoryChangeListener.class);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/PropertiesConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/PropertiesConfigFileTest.java
@@ -10,6 +10,8 @@ import com.ctrip.framework.apollo.ConfigFileChangeListener;
 import com.ctrip.framework.apollo.enums.PropertyChangeType;
 import com.ctrip.framework.apollo.model.ConfigFileChangeEvent;
 import com.google.common.util.concurrent.SettableFuture;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import java.util.concurrent.TimeUnit;
@@ -37,10 +39,10 @@ public class PropertiesConfigFileTest {
 
   @Test
   public void testWhenHasContent() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
-    someProperties.setProperty(someKey, someValue);
+    someProperties.put(someKey, someValue);
 
     when(configRepository.getConfig()).thenReturn(someProperties);
 
@@ -74,11 +76,11 @@ public class PropertiesConfigFileTest {
 
   @Test
   public void testOnRepositoryChange() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
     String anotherValue = "anotherValue";
-    someProperties.setProperty(someKey, someValue);
+    someProperties.put(someKey, someValue);
 
     when(configRepository.getConfig()).thenReturn(someProperties);
 
@@ -86,8 +88,8 @@ public class PropertiesConfigFileTest {
 
     assertTrue(configFile.getContent().contains(String.format("%s=%s", someKey, someValue)));
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(someKey, anotherValue);
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(someKey, anotherValue);
 
     final SettableFuture<ConfigFileChangeEvent> configFileChangeFuture = SettableFuture.create();
     ConfigFileChangeListener someListener = new ConfigFileChangeListener() {
@@ -114,10 +116,10 @@ public class PropertiesConfigFileTest {
 
   @Test
   public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
-    someProperties.setProperty(someKey, someValue);
+    someProperties.put(someKey, someValue);
 
     when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -1,40 +1,11 @@
 package com.ctrip.framework.apollo.internals;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.ctrip.framework.apollo.enums.ConfigSourceType;
-import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
-import javax.servlet.http.HttpServletResponse;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
-
 import com.ctrip.framework.apollo.build.MockInjector;
 import com.ctrip.framework.apollo.core.dto.ApolloConfig;
 import com.ctrip.framework.apollo.core.dto.ApolloConfigNotification;
 import com.ctrip.framework.apollo.core.dto.ApolloNotificationMessages;
 import com.ctrip.framework.apollo.core.dto.ServiceDTO;
+import com.ctrip.framework.apollo.enums.ConfigSourceType;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
 import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.ctrip.framework.apollo.util.http.HttpRequest;
@@ -46,271 +17,292 @@ import com.google.common.collect.Maps;
 import com.google.common.net.UrlEscapers;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 
 /**
  * Created by Jason on 4/9/16.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteConfigRepositoryTest {
-  @Mock
-  private ConfigServiceLocator configServiceLocator;
-  private String someNamespace;
-  private String someServerUrl;
-  private ConfigUtil configUtil;
-  private HttpUtil httpUtil;
-  @Mock
-  private static HttpResponse<ApolloConfig> someResponse;
-  @Mock
-  private static HttpResponse<List<ApolloConfigNotification>> pollResponse;
-  private RemoteConfigLongPollService remoteConfigLongPollService;
+    @Mock
+    private static HttpResponse<ApolloConfig> someResponse;
+    @Mock
+    private static HttpResponse<List<ApolloConfigNotification>> pollResponse;
+    @Mock
+    private ConfigServiceLocator configServiceLocator;
+    private String someNamespace;
+    private String someServerUrl;
+    private ConfigUtil configUtil;
+    private HttpUtil httpUtil;
+    private RemoteConfigLongPollService remoteConfigLongPollService;
 
-  @Before
-  public void setUp() throws Exception {
-    someNamespace = "someName";
+    @Before
+    public void setUp() throws Exception {
+        someNamespace = "someName";
 
-    when(pollResponse.getStatusCode()).thenReturn(HttpServletResponse.SC_NOT_MODIFIED);
+        when(pollResponse.getStatusCode()).thenReturn(HttpServletResponse.SC_NOT_MODIFIED);
 
-    MockInjector.reset();
-    configUtil = new MockConfigUtil();
-    MockInjector.setInstance(ConfigUtil.class, configUtil);
+        MockInjector.reset();
+        configUtil = new MockConfigUtil();
+        MockInjector.setInstance(ConfigUtil.class, configUtil);
 
-    someServerUrl = "http://someServer";
+        someServerUrl = "http://someServer";
 
-    ServiceDTO serviceDTO = mock(ServiceDTO.class);
+        ServiceDTO serviceDTO = mock(ServiceDTO.class);
 
-    when(serviceDTO.getHomepageUrl()).thenReturn(someServerUrl);
-    when(configServiceLocator.getConfigServices()).thenReturn(Lists.newArrayList(serviceDTO));
-    MockInjector.setInstance(ConfigServiceLocator.class, configServiceLocator);
+        when(serviceDTO.getHomepageUrl()).thenReturn(someServerUrl);
+        when(configServiceLocator.getConfigServices()).thenReturn(Lists.newArrayList(serviceDTO));
+        MockInjector.setInstance(ConfigServiceLocator.class, configServiceLocator);
 
-    httpUtil = spy(new MockHttpUtil());
-    MockInjector.setInstance(HttpUtil.class, httpUtil);
+        httpUtil = spy(new MockHttpUtil());
+        MockInjector.setInstance(HttpUtil.class, httpUtil);
 
-    remoteConfigLongPollService = new RemoteConfigLongPollService();
+        remoteConfigLongPollService = new RemoteConfigLongPollService();
 
-    MockInjector.setInstance(RemoteConfigLongPollService.class, remoteConfigLongPollService);
-  }
-
-  @Test
-  public void testLoadConfig() throws Exception {
-    String someKey = "someKey";
-    String someValue = "someValue";
-    Map<String, String> configurations = Maps.newHashMap();
-    configurations.put(someKey, someValue);
-    ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
-
-    when(someResponse.getStatusCode()).thenReturn(200);
-    when(someResponse.getBody()).thenReturn(someApolloConfig);
-
-    RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
-
-    Properties config = remoteConfigRepository.getConfig();
-
-    assertEquals(configurations, config);
-    assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
-    remoteConfigLongPollService.stopLongPollingRefresh();
-  }
-
-  @Test(expected = ApolloConfigException.class)
-  public void testGetRemoteConfigWithServerError() throws Exception {
-
-    when(someResponse.getStatusCode()).thenReturn(500);
-
-    RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
-
-    //must stop the long polling before exception occurred
-    remoteConfigLongPollService.stopLongPollingRefresh();
-
-    remoteConfigRepository.getConfig();
-  }
-
-  @Test
-  public void testRepositoryChangeListener() throws Exception {
-    Map<String, String> configurations = ImmutableMap.of("someKey", "someValue");
-    ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
-
-    when(someResponse.getStatusCode()).thenReturn(200);
-    when(someResponse.getBody()).thenReturn(someApolloConfig);
-
-    RepositoryChangeListener someListener = mock(RepositoryChangeListener.class);
-    RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
-    remoteConfigRepository.addChangeListener(someListener);
-    final ArgumentCaptor<Properties> captor = ArgumentCaptor.forClass(Properties.class);
-
-    Map<String, String> newConfigurations = ImmutableMap.of("someKey", "anotherValue");
-    ApolloConfig newApolloConfig = assembleApolloConfig(newConfigurations);
-
-    when(someResponse.getBody()).thenReturn(newApolloConfig);
-
-    remoteConfigRepository.sync();
-
-    verify(someListener, times(1)).onRepositoryChange(eq(someNamespace), captor.capture());
-
-    assertEquals(newConfigurations, captor.getValue());
-
-    remoteConfigLongPollService.stopLongPollingRefresh();
-  }
-
-  @Test
-  public void testLongPollingRefresh() throws Exception {
-    Map<String, String> configurations = ImmutableMap.of("someKey", "someValue");
-    ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
-
-    when(someResponse.getStatusCode()).thenReturn(200);
-    when(someResponse.getBody()).thenReturn(someApolloConfig);
-
-    final SettableFuture<Boolean> longPollFinished = SettableFuture.create();
-    RepositoryChangeListener someListener = mock(RepositoryChangeListener.class);
-    doAnswer(new Answer<Void>() {
-
-      @Override
-      public Void answer(InvocationOnMock invocation) throws Throwable {
-        longPollFinished.set(true);
-        return null;
-      }
-
-    }).when(someListener).onRepositoryChange(any(String.class), any(Properties.class));
-
-    RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
-    remoteConfigRepository.addChangeListener(someListener);
-    final ArgumentCaptor<Properties> captor = ArgumentCaptor.forClass(Properties.class);
-
-    Map<String, String> newConfigurations = ImmutableMap.of("someKey", "anotherValue");
-    ApolloConfig newApolloConfig = assembleApolloConfig(newConfigurations);
-
-    ApolloNotificationMessages notificationMessages = new ApolloNotificationMessages();
-    String someKey = "someKey";
-    long someNotificationId = 1;
-    notificationMessages.put(someKey, someNotificationId);
-
-    ApolloConfigNotification someNotification = mock(ApolloConfigNotification.class);
-    when(someNotification.getNamespaceName()).thenReturn(someNamespace);
-    when(someNotification.getMessages()).thenReturn(notificationMessages);
-
-    when(pollResponse.getStatusCode()).thenReturn(HttpServletResponse.SC_OK);
-    when(pollResponse.getBody()).thenReturn(Lists.newArrayList(someNotification));
-    when(someResponse.getBody()).thenReturn(newApolloConfig);
-
-    longPollFinished.get(5000, TimeUnit.MILLISECONDS);
-
-    remoteConfigLongPollService.stopLongPollingRefresh();
-
-    verify(someListener, times(1)).onRepositoryChange(eq(someNamespace), captor.capture());
-    assertEquals(newConfigurations, captor.getValue());
-
-    final ArgumentCaptor<HttpRequest> httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-    verify(httpUtil, atLeast(2)).doGet(httpRequestArgumentCaptor.capture(), eq(ApolloConfig.class));
-
-    HttpRequest request = httpRequestArgumentCaptor.getValue();
-
-    assertTrue(request.getUrl().contains("messages=%7B%22details%22%3A%7B%22someKey%22%3A1%7D%7D"));
-  }
-
-  @Test
-  public void testAssembleQueryConfigUrl() throws Exception {
-    Gson gson = new Gson();
-    String someUri = "http://someServer";
-    String someAppId = "someAppId";
-    String someCluster = "someCluster+ &.-_someSign";
-    String someReleaseKey = "20160705193346-583078ef5716c055+20160705193308-31c471ddf9087c3f";
-
-    ApolloNotificationMessages notificationMessages = new ApolloNotificationMessages();
-    String someKey = "someKey";
-    long someNotificationId = 1;
-    String anotherKey = "anotherKey";
-    long anotherNotificationId = 2;
-    notificationMessages.put(someKey, someNotificationId);
-    notificationMessages.put(anotherKey, anotherNotificationId);
-
-    RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
-    ApolloConfig someApolloConfig = mock(ApolloConfig.class);
-    when(someApolloConfig.getReleaseKey()).thenReturn(someReleaseKey);
-
-    String queryConfigUrl = remoteConfigRepository
-        .assembleQueryConfigUrl(someUri, someAppId, someCluster, someNamespace, null, notificationMessages,
-            someApolloConfig);
-
-    remoteConfigLongPollService.stopLongPollingRefresh();
-    assertTrue(queryConfigUrl
-        .contains(
-            "http://someServer/configs/someAppId/someCluster+%20&.-_someSign/" + someNamespace));
-    assertTrue(queryConfigUrl
-        .contains("releaseKey=20160705193346-583078ef5716c055%2B20160705193308-31c471ddf9087c3f"));
-    assertTrue(queryConfigUrl
-        .contains("messages=" + UrlEscapers.urlFormParameterEscaper().escape(gson.toJson(notificationMessages))));
-  }
-
-  private ApolloConfig assembleApolloConfig(Map<String, String> configurations) {
-    String someAppId = "appId";
-    String someClusterName = "cluster";
-    String someReleaseKey = "1";
-    ApolloConfig apolloConfig =
-        new ApolloConfig(someAppId, someClusterName, someNamespace, someReleaseKey);
-
-    apolloConfig.setConfigurations(configurations);
-
-    return apolloConfig;
-  }
-
-  public static class MockConfigUtil extends ConfigUtil {
-    @Override
-    public String getAppId() {
-      return "someApp";
+        MockInjector.setInstance(RemoteConfigLongPollService.class, remoteConfigLongPollService);
     }
 
-    @Override
-    public String getCluster() {
-      return "someCluster";
+    @Test
+    public void testLoadConfig() throws Exception {
+        String someKey = "someKey";
+        String someValue = "someValue";
+        Map<String, String> configurations = Maps.newHashMap();
+        configurations.put(someKey, someValue);
+        ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
+
+        when(someResponse.getStatusCode()).thenReturn(200);
+        when(someResponse.getBody()).thenReturn(someApolloConfig);
+
+        RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
+
+        LinkedHashMap config = remoteConfigRepository.getConfig();
+
+        assertEquals(configurations, config);
+        assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
+        remoteConfigLongPollService.stopLongPollingRefresh();
     }
 
-    @Override
-    public String getDataCenter() {
-      return null;
+    @Test(expected = ApolloConfigException.class)
+    public void testGetRemoteConfigWithServerError() throws Exception {
+
+        when(someResponse.getStatusCode()).thenReturn(500);
+
+        RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
+
+        //must stop the long polling before exception occurred
+        remoteConfigLongPollService.stopLongPollingRefresh();
+
+        remoteConfigRepository.getConfig();
     }
 
-    @Override
-    public int getLoadConfigQPS() {
-      return 200;
+    @Test
+    public void testRepositoryChangeListener() throws Exception {
+        Map<String, String> configurations = ImmutableMap.of("someKey", "someValue");
+        ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
+
+        when(someResponse.getStatusCode()).thenReturn(200);
+        when(someResponse.getBody()).thenReturn(someApolloConfig);
+
+        RepositoryChangeListener someListener = mock(RepositoryChangeListener.class);
+        RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
+        remoteConfigRepository.addChangeListener(someListener);
+        final ArgumentCaptor<LinkedHashMap> captor = ArgumentCaptor.forClass(LinkedHashMap.class);
+
+        Map<String, String> newConfigurations = ImmutableMap.of("someKey", "anotherValue");
+        ApolloConfig newApolloConfig = assembleApolloConfig(newConfigurations);
+
+        when(someResponse.getBody()).thenReturn(newApolloConfig);
+
+        remoteConfigRepository.sync();
+
+        verify(someListener, times(1)).onRepositoryChange(eq(someNamespace), captor.capture());
+
+        assertEquals(newConfigurations, captor.getValue());
+
+        remoteConfigLongPollService.stopLongPollingRefresh();
     }
 
-    @Override
-    public int getLongPollQPS() {
-      return 200;
+    @Test
+    public void testLongPollingRefresh() throws Exception {
+        Map<String, String> configurations = ImmutableMap.of("someKey", "someValue");
+        ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
+
+        when(someResponse.getStatusCode()).thenReturn(200);
+        when(someResponse.getBody()).thenReturn(someApolloConfig);
+
+        final SettableFuture<Boolean> longPollFinished = SettableFuture.create();
+        RepositoryChangeListener someListener = mock(RepositoryChangeListener.class);
+        doAnswer(new Answer<Void>() {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                longPollFinished.set(true);
+                return null;
+            }
+
+        }).when(someListener).onRepositoryChange(any(String.class), any(LinkedHashMap.class));
+
+        RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
+        remoteConfigRepository.addChangeListener(someListener);
+        final ArgumentCaptor<LinkedHashMap> captor = ArgumentCaptor.forClass(LinkedHashMap.class);
+
+        Map<String, String> newConfigurations = ImmutableMap.of("someKey", "anotherValue");
+        ApolloConfig newApolloConfig = assembleApolloConfig(newConfigurations);
+
+        ApolloNotificationMessages notificationMessages = new ApolloNotificationMessages();
+        String someKey = "someKey";
+        long someNotificationId = 1;
+        notificationMessages.put(someKey, someNotificationId);
+
+        ApolloConfigNotification someNotification = mock(ApolloConfigNotification.class);
+        when(someNotification.getNamespaceName()).thenReturn(someNamespace);
+        when(someNotification.getMessages()).thenReturn(notificationMessages);
+
+        when(pollResponse.getStatusCode()).thenReturn(HttpServletResponse.SC_OK);
+        when(pollResponse.getBody()).thenReturn(Lists.newArrayList(someNotification));
+        when(someResponse.getBody()).thenReturn(newApolloConfig);
+
+        longPollFinished.get(5000, TimeUnit.MILLISECONDS);
+
+        remoteConfigLongPollService.stopLongPollingRefresh();
+
+        verify(someListener, times(1)).onRepositoryChange(eq(someNamespace), captor.capture());
+        assertEquals(newConfigurations, captor.getValue());
+
+        final ArgumentCaptor<HttpRequest> httpRequestArgumentCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpUtil, atLeast(2)).doGet(httpRequestArgumentCaptor.capture(), eq(ApolloConfig.class));
+
+        HttpRequest request = httpRequestArgumentCaptor.getValue();
+
+        assertTrue(request.getUrl().contains("messages=%7B%22details%22%3A%7B%22someKey%22%3A1%7D%7D"));
     }
 
-    @Override
-    public long getOnErrorRetryInterval() {
-      return 10;
+    @Test
+    public void testAssembleQueryConfigUrl() throws Exception {
+        Gson gson = new Gson();
+        String someUri = "http://someServer";
+        String someAppId = "someAppId";
+        String someCluster = "someCluster+ &.-_someSign";
+        String someReleaseKey = "20160705193346-583078ef5716c055+20160705193308-31c471ddf9087c3f";
+
+        ApolloNotificationMessages notificationMessages = new ApolloNotificationMessages();
+        String someKey = "someKey";
+        long someNotificationId = 1;
+        String anotherKey = "anotherKey";
+        long anotherNotificationId = 2;
+        notificationMessages.put(someKey, someNotificationId);
+        notificationMessages.put(anotherKey, anotherNotificationId);
+
+        RemoteConfigRepository remoteConfigRepository = new RemoteConfigRepository(someNamespace);
+        ApolloConfig someApolloConfig = mock(ApolloConfig.class);
+        when(someApolloConfig.getReleaseKey()).thenReturn(someReleaseKey);
+
+        String queryConfigUrl = remoteConfigRepository
+                .assembleQueryConfigUrl(someUri, someAppId, someCluster, someNamespace, null, notificationMessages,
+                        someApolloConfig);
+
+        remoteConfigLongPollService.stopLongPollingRefresh();
+        assertTrue(queryConfigUrl
+                .contains(
+                        "http://someServer/configs/someAppId/someCluster+%20&.-_someSign/" + someNamespace));
+        assertTrue(queryConfigUrl
+                .contains("releaseKey=20160705193346-583078ef5716c055%2B20160705193308-31c471ddf9087c3f"));
+        assertTrue(queryConfigUrl
+                .contains("messages=" + UrlEscapers.urlFormParameterEscaper().escape(gson.toJson(notificationMessages))));
     }
 
-    @Override
-    public TimeUnit getOnErrorRetryIntervalTimeUnit() {
-      return TimeUnit.MILLISECONDS;
+    private ApolloConfig assembleApolloConfig(Map<String, String> configurations) {
+        String someAppId = "appId";
+        String someClusterName = "cluster";
+        String someReleaseKey = "1";
+        ApolloConfig apolloConfig =
+                new ApolloConfig(someAppId, someClusterName, someNamespace, someReleaseKey);
+
+        apolloConfig.setConfigurations(configurations);
+
+        return apolloConfig;
     }
 
-    @Override
-    public long getLongPollingInitialDelayInMills() {
-      return 0;
-    }
-  }
+    public static class MockConfigUtil extends ConfigUtil {
+        @Override
+        public String getAppId() {
+            return "someApp";
+        }
 
-  public static class MockHttpUtil extends HttpUtil {
-    @Override
-    public <T> HttpResponse<T> doGet(HttpRequest httpRequest, Class<T> responseType) {
-      if (someResponse.getStatusCode() == 200 || someResponse.getStatusCode() == 304 ) {
-        return (HttpResponse<T>) someResponse;
-      }
-      throw new ApolloConfigException(String.format("Http request failed due to status code: %d",
-          someResponse.getStatusCode()));
+        @Override
+        public String getCluster() {
+            return "someCluster";
+        }
+
+        @Override
+        public String getDataCenter() {
+            return null;
+        }
+
+        @Override
+        public int getLoadConfigQPS() {
+            return 200;
+        }
+
+        @Override
+        public int getLongPollQPS() {
+            return 200;
+        }
+
+        @Override
+        public long getOnErrorRetryInterval() {
+            return 10;
+        }
+
+        @Override
+        public TimeUnit getOnErrorRetryIntervalTimeUnit() {
+            return TimeUnit.MILLISECONDS;
+        }
+
+        @Override
+        public long getLongPollingInitialDelayInMills() {
+            return 0;
+        }
     }
 
-    @Override
-    public <T> HttpResponse<T> doGet(HttpRequest httpRequest, Type responseType) {
-      try {
-        TimeUnit.MILLISECONDS.sleep(50);
-      } catch (InterruptedException e) {
-      }
-      return (HttpResponse<T>) pollResponse;
+    public static class MockHttpUtil extends HttpUtil {
+        @Override
+        public <T> HttpResponse<T> doGet(HttpRequest httpRequest, Class<T> responseType) {
+            if (someResponse.getStatusCode() == 200 || someResponse.getStatusCode() == 304) {
+                return (HttpResponse<T>) someResponse;
+            }
+            throw new ApolloConfigException(String.format("Http request failed due to status code: %d",
+                    someResponse.getStatusCode()));
+        }
+
+        @Override
+        public <T> HttpResponse<T> doGet(HttpRequest httpRequest, Type responseType) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(50);
+            } catch (InterruptedException e) {
+            }
+            return (HttpResponse<T>) pollResponse;
+        }
     }
-  }
 
 }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/SimpleConfigTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/SimpleConfigTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -39,10 +41,10 @@ public class SimpleConfigTest {
 
   @Test
   public void testGetProperty() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
-    someProperties.setProperty(someKey, someValue);
+    someProperties.put(someKey, someValue);
 
     someSourceType = ConfigSourceType.LOCAL;
 
@@ -70,14 +72,14 @@ public class SimpleConfigTest {
 
   @Test
   public void testOnRepositoryChange() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
     String anotherKey = "anotherKey";
     String anotherValue = "anotherValue";
     someProperties.putAll(ImmutableMap.of(someKey, someValue, anotherKey, anotherValue));
 
-    Properties anotherProperties = new Properties();
+    LinkedHashMap anotherProperties = new LinkedHashMap();
     String newKey = "newKey";
     String newValue = "newValue";
     String someValueNew = "someValueNew";

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/TxtConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/TxtConfigFileTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.core.enums.ConfigFileFormat;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,10 +28,10 @@ public class TxtConfigFileTest {
 
   @Test
   public void testWhenHasContent() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someValue";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     when(configRepository.getConfig()).thenReturn(someProperties);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/XmlConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/XmlConfigFileTest.java
@@ -10,6 +10,8 @@ import com.ctrip.framework.apollo.ConfigFileChangeListener;
 import com.ctrip.framework.apollo.enums.PropertyChangeType;
 import com.ctrip.framework.apollo.model.ConfigFileChangeEvent;
 import com.google.common.util.concurrent.SettableFuture;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import java.util.concurrent.TimeUnit;
@@ -38,10 +40,10 @@ public class XmlConfigFileTest {
 
   @Test
   public void testWhenHasContent() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someValue";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     when(configRepository.getConfig()).thenReturn(someProperties);
 
@@ -75,11 +77,11 @@ public class XmlConfigFileTest {
 
   @Test
   public void testOnRepositoryChange() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someValue";
     String anotherValue = "anotherValue";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     when(configRepository.getConfig()).thenReturn(someProperties);
 
@@ -87,8 +89,8 @@ public class XmlConfigFileTest {
 
     assertEquals(someValue, configFile.getContent());
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(key, anotherValue);
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(key, anotherValue);
 
     final SettableFuture<ConfigFileChangeEvent> configFileChangeFuture = SettableFuture.create();
     ConfigFileChangeListener someListener = new ConfigFileChangeListener() {
@@ -113,7 +115,7 @@ public class XmlConfigFileTest {
 
   @Test
   public void testOnRepositoryChangeWithContentAdded() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someValue";
 
@@ -123,8 +125,8 @@ public class XmlConfigFileTest {
 
     assertEquals(null, configFile.getContent());
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(key, someValue);
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(key, someValue);
 
     final SettableFuture<ConfigFileChangeEvent> configFileChangeFuture = SettableFuture.create();
     ConfigFileChangeListener someListener = new ConfigFileChangeListener() {
@@ -149,10 +151,10 @@ public class XmlConfigFileTest {
 
   @Test
   public void testOnRepositoryChangeWithContentDeleted() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someValue";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     when(configRepository.getConfig()).thenReturn(someProperties);
 
@@ -160,7 +162,7 @@ public class XmlConfigFileTest {
 
     assertEquals(someValue, configFile.getContent());
 
-    Properties anotherProperties = new Properties();
+    LinkedHashMap anotherProperties = new LinkedHashMap();
 
     final SettableFuture<ConfigFileChangeEvent> configFileChangeFuture = SettableFuture.create();
     ConfigFileChangeListener someListener = new ConfigFileChangeListener() {
@@ -185,10 +187,10 @@ public class XmlConfigFileTest {
 
   @Test
   public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someValue";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/YamlConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/YamlConfigFileTest.java
@@ -8,6 +8,8 @@ import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
 import com.ctrip.framework.apollo.exceptions.ApolloConfigException;
 import com.ctrip.framework.apollo.util.yaml.YamlParser;
+
+import java.util.LinkedHashMap;
 import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,14 +37,14 @@ public class YamlConfigFileTest {
 
   @Test
   public void testWhenHasContent() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someContent = "someKey: 'someValue'";
-    someProperties.setProperty(key, someContent);
+    someProperties.put(key, someContent);
     someSourceType = ConfigSourceType.LOCAL;
 
-    Properties yamlProperties = new Properties();
-    yamlProperties.setProperty("someKey", "someValue");
+    LinkedHashMap yamlProperties = new LinkedHashMap();
+    yamlProperties.put("someKey", "someValue");
 
     when(configRepository.getConfig()).thenReturn(someProperties);
     when(configRepository.getSourceType()).thenReturn(someSourceType);
@@ -63,17 +65,17 @@ public class YamlConfigFileTest {
     assertFalse(configFile.hasContent());
     assertNull(configFile.getContent());
 
-    Properties properties = configFile.asProperties();
+    LinkedHashMap properties = configFile.asProperties();
 
     assertTrue(properties.isEmpty());
   }
 
   @Test
   public void testWhenInvalidYamlContent() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someInvalidContent = ",";
-    someProperties.setProperty(key, someInvalidContent);
+    someProperties.put(key, someInvalidContent);
     someSourceType = ConfigSourceType.LOCAL;
 
     when(configRepository.getConfig()).thenReturn(someProperties);
@@ -105,26 +107,26 @@ public class YamlConfigFileTest {
     assertNull(configFile.getContent());
     assertEquals(ConfigSourceType.NONE, configFile.getSourceType());
 
-    Properties properties = configFile.asProperties();
+    LinkedHashMap properties = configFile.asProperties();
 
     assertTrue(properties.isEmpty());
   }
 
   @Test
   public void testOnRepositoryChange() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someKey: 'someValue'";
     String anotherValue = "anotherKey: 'anotherValue'";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     someSourceType = ConfigSourceType.LOCAL;
 
-    Properties someYamlProperties = new Properties();
-    someYamlProperties.setProperty("someKey", "someValue");
+    LinkedHashMap someYamlProperties = new LinkedHashMap();
+    someYamlProperties.put("someKey", "someValue");
 
-    Properties anotherYamlProperties = new Properties();
-    anotherYamlProperties.setProperty("anotherKey", "anotherValue");
+    LinkedHashMap anotherYamlProperties = new LinkedHashMap();
+    anotherYamlProperties.put("anotherKey", "anotherValue");
 
     when(configRepository.getConfig()).thenReturn(someProperties);
     when(configRepository.getSourceType()).thenReturn(someSourceType);
@@ -137,8 +139,8 @@ public class YamlConfigFileTest {
     assertEquals(someSourceType, configFile.getSourceType());
     assertSame(someYamlProperties, configFile.asProperties());
 
-    Properties anotherProperties = new Properties();
-    anotherProperties.setProperty(key, anotherValue);
+    LinkedHashMap anotherProperties = new LinkedHashMap();
+    anotherProperties.put(key, anotherValue);
 
     ConfigSourceType anotherSourceType = ConfigSourceType.REMOTE;
     when(configRepository.getSourceType()).thenReturn(anotherSourceType);
@@ -152,15 +154,15 @@ public class YamlConfigFileTest {
 
   @Test
   public void testWhenConfigRepositoryHasErrorAndThenRecovered() throws Exception {
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
     String someValue = "someKey: 'someValue'";
-    someProperties.setProperty(key, someValue);
+    someProperties.put(key, someValue);
 
     someSourceType = ConfigSourceType.LOCAL;
 
-    Properties someYamlProperties = new Properties();
-    someYamlProperties.setProperty("someKey", "someValue");
+    LinkedHashMap someYamlProperties = new LinkedHashMap();
+    someYamlProperties.put("someKey", "someValue");
 
     when(configRepository.getConfig()).thenThrow(new RuntimeException("someError"));
     when(configRepository.getSourceType()).thenReturn(someSourceType);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/YamlConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/YamlConfigFileTest.java
@@ -57,6 +57,35 @@ public class YamlConfigFileTest {
   }
 
   @Test
+  public void testWhenHasContentWithOrder() throws Exception {
+    LinkedHashMap someProperties = new LinkedHashMap();
+    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+    String someContent = "someKey: 'someValue'\n someKey2: 'someValue2'";
+    someProperties.put(key, someContent);
+    someSourceType = ConfigSourceType.LOCAL;
+
+    LinkedHashMap yamlProperties = new LinkedHashMap();
+    yamlProperties.put("someKey", "someValue");
+    yamlProperties.put("someKey2", "someValue2");
+
+    when(configRepository.getConfig()).thenReturn(someProperties);
+    when(configRepository.getSourceType()).thenReturn(someSourceType);
+    when(yamlParser.yamlToProperties(someContent)).thenReturn(yamlProperties);
+
+    YamlConfigFile configFile = new YamlConfigFile(someNamespace, configRepository);
+
+    assertSame(someContent, configFile.getContent());
+    assertSame(yamlProperties, configFile.asProperties());
+
+    LinkedHashMap parseResult=configFile.asProperties();
+
+    String[] keys =(String[]) parseResult.keySet().toArray(new String[]{});
+    assertEquals("someKey",keys[0]);
+    assertEquals("someKey2",keys[1]);
+  }
+
+
+  @Test
   public void testWhenHasNoContent() throws Exception {
     when(configRepository.getConfig()).thenReturn(null);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spi/DefaultConfigFactoryTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.ctrip.framework.apollo.internals.PropertiesCompatibleFileConfigRepository;
-import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +29,8 @@ import com.ctrip.framework.apollo.internals.XmlConfigFile;
 import com.ctrip.framework.apollo.internals.YamlConfigFile;
 import com.ctrip.framework.apollo.internals.YmlConfigFile;
 import com.ctrip.framework.apollo.util.ConfigUtil;
+
+import java.util.LinkedHashMap;
 
 /**
  * @author Jason Song(song_s@ctrip.com)
@@ -51,10 +52,10 @@ public class DefaultConfigFactoryTest {
   @Test
   public void testCreate() throws Exception {
     String someNamespace = "someName";
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
-    someProperties.setProperty(someKey, someValue);
+    someProperties.put(someKey, someValue);
 
     LocalFileConfigRepository someLocalConfigRepo = mock(LocalFileConfigRepository.class);
     when(someLocalConfigRepo.getConfig()).thenReturn(someProperties);
@@ -83,10 +84,10 @@ public class DefaultConfigFactoryTest {
   public void testCreatePropertiesCompatibleFileConfigRepository() throws Exception {
     ConfigFileFormat somePropertiesCompatibleFormat = ConfigFileFormat.YML;
     String someNamespace = "someName" + "." + somePropertiesCompatibleFormat;
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
     String someKey = "someKey";
     String someValue = "someValue";
-    someProperties.setProperty(someKey, someValue);
+    someProperties.put(someKey, someValue);
 
     PropertiesCompatibleFileConfigRepository someRepository = mock(PropertiesCompatibleFileConfigRepository.class);
     when(someRepository.getConfig()).thenReturn(someProperties);
@@ -106,7 +107,7 @@ public class DefaultConfigFactoryTest {
     String someNamespace = "someName";
     String anotherNamespace = "anotherName";
     String yetAnotherNamespace = "yetAnotherNamespace";
-    Properties someProperties = new Properties();
+    LinkedHashMap someProperties = new LinkedHashMap();
 
     LocalFileConfigRepository someLocalConfigRepo = mock(LocalFileConfigRepository.class);
     when(someLocalConfigRepo.getConfig()).thenReturn(someProperties);

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/AbstractSpringIntegrationTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/AbstractSpringIntegrationTest.java
@@ -17,9 +17,9 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-import java.util.Properties;
 import org.junit.After;
 import org.junit.Before;
 import org.springframework.util.ReflectionUtils;
@@ -62,7 +62,7 @@ public abstract class AbstractSpringIntegrationTest {
     doTearDown();
   }
 
-  protected SimpleConfig prepareConfig(String namespaceName, Properties properties) {
+  protected SimpleConfig prepareConfig(String namespaceName, LinkedHashMap properties) {
     ConfigRepository configRepository = mock(ConfigRepository.class);
 
     when(configRepository.getConfig()).thenReturn(properties);
@@ -74,18 +74,18 @@ public abstract class AbstractSpringIntegrationTest {
     return config;
   }
 
-  protected static Properties readYamlContentAsConfigFileProperties(String caseName) throws IOException {
+  protected static LinkedHashMap readYamlContentAsConfigFileProperties(String caseName) throws IOException {
     File file = new File("src/test/resources/spring/yaml/" + caseName);
 
     String yamlContent = Files.toString(file, Charsets.UTF_8);
 
-    Properties properties = new Properties();
-    properties.setProperty(ConfigConsts.CONFIG_FILE_CONTENT_KEY, yamlContent);
+    LinkedHashMap properties = new LinkedHashMap();
+    properties.put(ConfigConsts.CONFIG_FILE_CONTENT_KEY, yamlContent);
 
     return properties;
   }
 
-  protected static YamlConfigFile prepareYamlConfigFile(String namespaceNameWithFormat, Properties properties) {
+  protected static YamlConfigFile prepareYamlConfigFile(String namespaceNameWithFormat, LinkedHashMap properties) {
     ConfigRepository configRepository = mock(ConfigRepository.class);
 
     when(configRepository.getConfig()).thenReturn(properties);
@@ -97,28 +97,28 @@ public abstract class AbstractSpringIntegrationTest {
     return configFile;
   }
 
-  protected Properties assembleProperties(String key, String value) {
-    Properties properties = new Properties();
-    properties.setProperty(key, value);
+  protected LinkedHashMap assembleProperties(String key, String value) {
+    LinkedHashMap properties = new LinkedHashMap();
+    properties.put(key, value);
 
     return properties;
   }
 
-  protected Properties assembleProperties(String key, String value, String key2, String value2) {
-    Properties properties = new Properties();
-    properties.setProperty(key, value);
-    properties.setProperty(key2, value2);
+  protected LinkedHashMap assembleProperties(String key, String value, String key2, String value2) {
+    LinkedHashMap properties = new LinkedHashMap();
+    properties.put(key, value);
+    properties.put(key2, value2);
 
     return properties;
   }
 
-  protected Properties assembleProperties(String key, String value, String key2, String value2,
+  protected LinkedHashMap assembleProperties(String key, String value, String key2, String value2,
       String key3, String value3) {
 
-    Properties properties = new Properties();
-    properties.setProperty(key, value);
-    properties.setProperty(key2, value2);
-    properties.setProperty(key3, value3);
+    LinkedHashMap properties = new LinkedHashMap();
+    properties.put(key, value);
+    properties.put(key2, value2);
+    properties.put(key3, value3);
 
     return properties;
   }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderAutoUpdateTest.java
@@ -16,9 +16,9 @@ import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.primitives.Ints;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +49,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -61,7 +61,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -104,7 +104,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -119,7 +119,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, xmlBean.getTimeout());
     assertEquals(initialBatch, xmlBean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -174,7 +174,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     MockInjector.setInstance(ConfigUtil.class, mockConfigUtil);
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -186,7 +186,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -204,8 +204,8 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties applicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout));
-    Properties fxApolloProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(initialBatch));
+    LinkedHashMap applicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout));
+    LinkedHashMap fxApolloProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
     SimpleConfig fxApolloConfig = prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
@@ -217,7 +217,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout));
+    LinkedHashMap newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout));
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
 
@@ -226,7 +226,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newFxApolloProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(newBatch));
+    LinkedHashMap newFxApolloProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(newBatch));
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
 
@@ -244,8 +244,8 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int someNewTimeout = 1001;
     int someNewBatch = 2001;
 
-    Properties applicationProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(someBatch));
-    Properties fxApolloProperties =
+    LinkedHashMap applicationProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(someBatch));
+    LinkedHashMap fxApolloProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
     prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
@@ -258,7 +258,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(someTimeout, bean.getTimeout());
     assertEquals(someBatch, bean.getBatch());
 
-    Properties newFxApolloProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someNewTimeout),
+    LinkedHashMap newFxApolloProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someNewTimeout),
         BATCH_PROPERTY, String.valueOf(someNewBatch));
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
@@ -278,7 +278,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     YamlConfigFile configFile = prepareYamlConfigFile("application.yml",
         readYamlContentAsConfigFileProperties("case2.yml"));
-    Properties fxApolloProperties =
+    LinkedHashMap fxApolloProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
     prepareConfig(FX_APOLLO_NAMESPACE, fxApolloProperties);
@@ -304,7 +304,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties applicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout));
+    LinkedHashMap applicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
 
@@ -315,7 +315,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
 
-    Properties newApplicationProperties =
+    LinkedHashMap newApplicationProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
@@ -360,7 +360,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     String anotherIrrelevantKey = "anotherIrrelevantKey";
     String anotherIrrelevantValue = "anotherIrrelevantValue";
 
-    Properties applicationProperties =
+    LinkedHashMap applicationProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), someIrrelevantKey, someIrrelevantValue);
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
@@ -372,7 +372,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
 
-    Properties newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         anotherIrrelevantKey, String.valueOf(anotherIrrelevantValue));
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newApplicationProperties);
@@ -388,7 +388,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int initialTimeout = 1000;
     int initialBatch = 2000;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -400,7 +400,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -439,8 +439,8 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int someBatch = 2000;
     int anotherBatch = 3000;
 
-    Properties applicationProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(someBatch));
-    Properties fxApolloProperties =
+    LinkedHashMap applicationProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(someBatch));
+    LinkedHashMap fxApolloProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
@@ -453,7 +453,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(someTimeout, bean.getTimeout());
     assertEquals(someBatch, bean.getBatch());
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -469,7 +469,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int initialBatch = 2000;
     int newTimeout = 1001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -481,7 +481,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout));
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -498,7 +498,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     String newBatch = "newBatch";
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -510,7 +510,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, newBatch);
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -552,7 +552,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -564,7 +564,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -583,7 +583,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -595,7 +595,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -614,7 +614,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -626,7 +626,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -645,7 +645,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout), BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -657,7 +657,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties =
+    LinkedHashMap newProperties =
         assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -677,7 +677,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int someValue = 1234;
     int someNewValue = 2345;
 
-    Properties properties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
+    LinkedHashMap properties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
         String.format("%s.%s", someKeyValue, anotherKeyValue), String.valueOf(someValue));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -688,7 +688,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     assertEquals(someValue, bean.getNestedProperty());
 
-    Properties newProperties = assembleProperties(SOME_KEY_PROPERTY, newKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
+    LinkedHashMap newProperties = assembleProperties(SOME_KEY_PROPERTY, newKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
         String.format("%s.%s", newKeyValue, anotherKeyValue), String.valueOf(someNewValue));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -705,7 +705,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int someValue = 1234;
     int someNewValue = 2345;
 
-    Properties properties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
+    LinkedHashMap properties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
         String.format("%s.%s", someKeyValue, anotherKeyValue), String.valueOf(someValue));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -716,7 +716,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     assertEquals(someValue, bean.getNestedProperty());
 
-    Properties newProperties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY,
+    LinkedHashMap newProperties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY,
         anotherKeyValue, String.format("%s.%s", someKeyValue, anotherKeyValue), String.valueOf(someNewValue));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -734,7 +734,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int someValue = 1234;
     int someNewValue = 2345;
 
-    Properties properties =
+    LinkedHashMap properties =
         assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, String.valueOf(someValue));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -745,7 +745,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     assertEquals(someValue, bean.getNestedProperty());
 
-    Properties newProperties = assembleProperties(SOME_KEY_PROPERTY, someNewKeyValue, ANOTHER_KEY_PROPERTY,
+    LinkedHashMap newProperties = assembleProperties(SOME_KEY_PROPERTY, someNewKeyValue, ANOTHER_KEY_PROPERTY,
         String.valueOf(someValue), someNewKeyValue, String.valueOf(someNewValue));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -767,10 +767,10 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     int someValue = 1234;
     int someNewValue = 2345;
 
-    Properties properties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
+    LinkedHashMap properties = assembleProperties(SOME_KEY_PROPERTY, someKeyValue, ANOTHER_KEY_PROPERTY, anotherKeyValue,
         someKeyValue, someNestedPlaceholder);
 
-    properties.setProperty(someNestedKey, String.valueOf(someValue));
+    properties.put(someNestedKey, String.valueOf(someValue));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
 
@@ -780,10 +780,10 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
 
     assertEquals(someValue, bean.getNestedProperty());
 
-    Properties newProperties = assembleProperties(SOME_KEY_PROPERTY, someNewKeyValue, ANOTHER_KEY_PROPERTY,
+    LinkedHashMap newProperties = assembleProperties(SOME_KEY_PROPERTY, someNewKeyValue, ANOTHER_KEY_PROPERTY,
         anotherKeyValue, someNewKeyValue, anotherNestedPlaceholder);
 
-    newProperties.setProperty(anotherNestedKey, String.valueOf(someNewValue));
+    newProperties.put(anotherNestedKey, String.valueOf(someNewValue));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -820,19 +820,19 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     Date someNewDate = assembleDate(2018, 2, 23, 21, 2, 3, 345);
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(someDateFormat, Locale.US);
 
-    Properties properties = new Properties();
-    properties.setProperty("intProperty", String.valueOf(someInt));
-    properties.setProperty("intArrayProperty", Ints.join(", ", someIntArray));
-    properties.setProperty("longProperty", String.valueOf(someLong));
-    properties.setProperty("shortProperty", String.valueOf(someShort));
-    properties.setProperty("floatProperty", String.valueOf(someFloat));
-    properties.setProperty("doubleProperty", String.valueOf(someDouble));
-    properties.setProperty("byteProperty", String.valueOf(someByte));
-    properties.setProperty("booleanProperty", String.valueOf(someBoolean));
-    properties.setProperty("stringProperty", String.valueOf(someString));
-    properties.setProperty("dateFormat", String.valueOf(someDateFormat));
-    properties.setProperty("dateProperty", simpleDateFormat.format(someDate));
-    properties.setProperty("jsonProperty", someJsonProperty);
+    LinkedHashMap properties = new LinkedHashMap();
+    properties.put("intProperty", String.valueOf(someInt));
+    properties.put("intArrayProperty", Ints.join(", ", someIntArray));
+    properties.put("longProperty", String.valueOf(someLong));
+    properties.put("shortProperty", String.valueOf(someShort));
+    properties.put("floatProperty", String.valueOf(someFloat));
+    properties.put("doubleProperty", String.valueOf(someDouble));
+    properties.put("byteProperty", String.valueOf(someByte));
+    properties.put("booleanProperty", String.valueOf(someBoolean));
+    properties.put("stringProperty", String.valueOf(someString));
+    properties.put("dateFormat", String.valueOf(someDateFormat));
+    properties.put("dateProperty", simpleDateFormat.format(someDate));
+    properties.put("jsonProperty", someJsonProperty);
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
 
@@ -853,19 +853,19 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals("astring", bean.getJsonBeanList().get(0).getA());
     assertEquals(10, bean.getJsonBeanList().get(0).getB());
 
-    Properties newProperties = new Properties();
-    newProperties.setProperty("intProperty", String.valueOf(someNewInt));
-    newProperties.setProperty("intArrayProperty", Ints.join(", ", someNewIntArray));
-    newProperties.setProperty("longProperty", String.valueOf(someNewLong));
-    newProperties.setProperty("shortProperty", String.valueOf(someNewShort));
-    newProperties.setProperty("floatProperty", String.valueOf(someNewFloat));
-    newProperties.setProperty("doubleProperty", String.valueOf(someNewDouble));
-    newProperties.setProperty("byteProperty", String.valueOf(someNewByte));
-    newProperties.setProperty("booleanProperty", String.valueOf(someNewBoolean));
-    newProperties.setProperty("stringProperty", String.valueOf(someNewString));
-    newProperties.setProperty("dateFormat", String.valueOf(someDateFormat));
-    newProperties.setProperty("dateProperty", simpleDateFormat.format(someNewDate));
-    newProperties.setProperty("jsonProperty", someNewJsonProperty);
+    LinkedHashMap newProperties = new LinkedHashMap();
+    newProperties.put("intProperty", String.valueOf(someNewInt));
+    newProperties.put("intArrayProperty", Ints.join(", ", someNewIntArray));
+    newProperties.put("longProperty", String.valueOf(someNewLong));
+    newProperties.put("shortProperty", String.valueOf(someNewShort));
+    newProperties.put("floatProperty", String.valueOf(someNewFloat));
+    newProperties.put("doubleProperty", String.valueOf(someNewDouble));
+    newProperties.put("byteProperty", String.valueOf(someNewByte));
+    newProperties.put("booleanProperty", String.valueOf(someNewBoolean));
+    newProperties.put("stringProperty", String.valueOf(someNewString));
+    newProperties.put("dateFormat", String.valueOf(someDateFormat));
+    newProperties.put("dateProperty", simpleDateFormat.format(someNewDate));
+    newProperties.put("jsonProperty", someNewJsonProperty);
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -890,7 +890,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     String someValidValue = "{\"a\":\"someString\", \"b\":10}";
     String someInvalidValue = "someInvalidValue";
 
-    Properties properties = assembleProperties("jsonProperty", someValidValue);
+    LinkedHashMap properties = assembleProperties("jsonProperty", someValidValue);
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
 
@@ -903,7 +903,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals("someString", jsonBean.getA());
     assertEquals(10, jsonBean.getB());
 
-    Properties newProperties = assembleProperties("jsonProperty", someInvalidValue);
+    LinkedHashMap newProperties = assembleProperties("jsonProperty", someInvalidValue);
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -917,7 +917,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
   public void testAutoUpdateJsonValueWithNoValueAndNoDefaultValue() throws Exception {
     String someValidValue = "{\"a\":\"someString\", \"b\":10}";
 
-    Properties properties = assembleProperties("jsonProperty", someValidValue);
+    LinkedHashMap properties = assembleProperties("jsonProperty", someValidValue);
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
 
@@ -930,7 +930,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals("someString", jsonBean.getA());
     assertEquals(10, jsonBean.getB());
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -944,7 +944,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
   public void testAutoUpdateJsonValueWithNoValueAndDefaultValue() throws Exception {
     String someValidValue = "{\"a\":\"someString\", \"b\":10}";
 
-    Properties properties = assembleProperties("jsonProperty", someValidValue);
+    LinkedHashMap properties = assembleProperties("jsonProperty", someValidValue);
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
 
@@ -957,7 +957,7 @@ public class JavaConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegrati
     assertEquals("someString", jsonBean.getA());
     assertEquals(10, jsonBean.getB());
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/JavaConfigPlaceholderTest.java
@@ -11,8 +11,9 @@ import com.ctrip.framework.apollo.PropertiesCompatibleConfigFile;
 import com.ctrip.framework.apollo.core.ConfigConsts;
 import com.ctrip.framework.apollo.spring.annotation.ApolloJsonValue;
 import com.ctrip.framework.apollo.spring.annotation.EnableApolloConfig;
+
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Properties;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,10 +77,10 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
   public void testPropertiesCompatiblePropertySource() throws Exception {
     int someTimeout = 1000;
     int someBatch = 2000;
-    Properties properties = mock(Properties.class);
+    LinkedHashMap properties = mock(LinkedHashMap.class);
 
-    when(properties.getProperty(TIMEOUT_PROPERTY)).thenReturn(String.valueOf(someTimeout));
-    when(properties.getProperty(BATCH_PROPERTY)).thenReturn(String.valueOf(someBatch));
+    when(properties.get(TIMEOUT_PROPERTY)).thenReturn(String.valueOf(someTimeout));
+    when(properties.get(BATCH_PROPERTY)).thenReturn(String.valueOf(someBatch));
     PropertiesCompatibleConfigFile configFile = mock(PropertiesCompatibleConfigFile.class);
     when(configFile.asProperties()).thenReturn(properties);
 
@@ -92,10 +93,10 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
   public void testPropertiesCompatiblePropertySourceWithNonNormalizedCase() throws Exception {
     int someTimeout = 1000;
     int someBatch = 2000;
-    Properties properties = mock(Properties.class);
+    LinkedHashMap properties = mock(LinkedHashMap.class);
 
-    when(properties.getProperty(TIMEOUT_PROPERTY)).thenReturn(String.valueOf(someTimeout));
-    when(properties.getProperty(BATCH_PROPERTY)).thenReturn(String.valueOf(someBatch));
+    when(properties.get(TIMEOUT_PROPERTY)).thenReturn(String.valueOf(someTimeout));
+    when(properties.get(BATCH_PROPERTY)).thenReturn(String.valueOf(someBatch));
     PropertiesCompatibleConfigFile configFile = mock(PropertiesCompatibleConfigFile.class);
     when(configFile.asProperties()).thenReturn(properties);
 
@@ -126,10 +127,10 @@ public class JavaConfigPlaceholderTest extends AbstractSpringIntegrationTest {
     int anotherTimeout = someTimeout + 1;
     int someBatch = 2000;
 
-    Properties properties = mock(Properties.class);
+    LinkedHashMap properties = mock(LinkedHashMap.class);
 
-    when(properties.getProperty(TIMEOUT_PROPERTY)).thenReturn(String.valueOf(someTimeout));
-    when(properties.getProperty(BATCH_PROPERTY)).thenReturn(String.valueOf(someBatch));
+    when(properties.get(TIMEOUT_PROPERTY)).thenReturn(String.valueOf(someTimeout));
+    when(properties.get(BATCH_PROPERTY)).thenReturn(String.valueOf(someBatch));
     PropertiesCompatibleConfigFile configFile = mock(PropertiesCompatibleConfigFile.class);
     when(configFile.asProperties()).thenReturn(properties);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/XmlConfigPlaceholderAutoUpdateTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/spring/XmlConfigPlaceholderAutoUpdateTest.java
@@ -11,8 +11,8 @@ import com.ctrip.framework.apollo.util.ConfigUtil;
 import com.google.common.primitives.Ints;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Locale;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,7 +32,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -44,7 +44,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
         BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -67,7 +67,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
 
     MockInjector.setInstance(ConfigUtil.class, mockConfigUtil);
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -79,7 +79,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
         BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -97,9 +97,9 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties applicationProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap applicationProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(initialTimeout));
-    Properties fxApolloProperties = assembleProperties(BATCH_PROPERTY,
+    LinkedHashMap fxApolloProperties = assembleProperties(BATCH_PROPERTY,
         String.valueOf(initialBatch));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION,
@@ -113,7 +113,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(newTimeout));
 
     applicationConfig
@@ -124,7 +124,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(newTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newFxApolloProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(newBatch));
+    LinkedHashMap newFxApolloProperties = assembleProperties(BATCH_PROPERTY, String.valueOf(newBatch));
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
 
@@ -142,9 +142,9 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int someNewTimeout = 1001;
     int someNewBatch = 2001;
 
-    Properties applicationProperties = assembleProperties(BATCH_PROPERTY,
+    LinkedHashMap applicationProperties = assembleProperties(BATCH_PROPERTY,
         String.valueOf(someBatch));
-    Properties fxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap fxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
     prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, applicationProperties);
@@ -157,7 +157,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(someTimeout, bean.getTimeout());
     assertEquals(someBatch, bean.getBatch());
 
-    Properties newFxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap newFxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(someNewTimeout), BATCH_PROPERTY, String.valueOf(someNewBatch));
 
     fxApolloConfig.onRepositoryChange(FX_APOLLO_NAMESPACE, newFxApolloProperties);
@@ -174,7 +174,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties applicationProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap applicationProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(initialTimeout));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION,
@@ -187,7 +187,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
 
-    Properties newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(newTimeout), BATCH_PROPERTY, String.valueOf(newBatch));
 
     applicationConfig
@@ -209,7 +209,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     String anotherIrrelevantKey = "anotherIrrelevantKey";
     String anotherIrrelevantValue = "anotherIrrelevantValue";
 
-    Properties applicationProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap applicationProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(initialTimeout), someIrrelevantKey, someIrrelevantValue);
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION,
@@ -222,7 +222,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(DEFAULT_BATCH, bean.getBatch());
 
-    Properties newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap newApplicationProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(initialTimeout), anotherIrrelevantKey, String.valueOf(anotherIrrelevantValue));
 
     applicationConfig
@@ -239,7 +239,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int initialTimeout = 1000;
     int initialBatch = 2000;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -251,7 +251,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -267,9 +267,9 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int someBatch = 2000;
     int anotherBatch = 3000;
 
-    Properties applicationProperties = assembleProperties(BATCH_PROPERTY,
+    LinkedHashMap applicationProperties = assembleProperties(BATCH_PROPERTY,
         String.valueOf(someBatch));
-    Properties fxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
+    LinkedHashMap fxApolloProperties = assembleProperties(TIMEOUT_PROPERTY,
         String.valueOf(someTimeout), BATCH_PROPERTY, String.valueOf(anotherBatch));
 
     SimpleConfig applicationConfig = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION,
@@ -283,7 +283,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(someTimeout, bean.getTimeout());
     assertEquals(someBatch, bean.getBatch());
 
-    Properties newProperties = new Properties();
+    LinkedHashMap newProperties = new LinkedHashMap();
 
     applicationConfig.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -299,7 +299,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int initialBatch = 2000;
     int newTimeout = 1001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -311,7 +311,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout));
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 
@@ -328,7 +328,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int newTimeout = 1001;
     String newBatch = "newBatch";
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -340,7 +340,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
         BATCH_PROPERTY, newBatch);
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -358,7 +358,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -370,7 +370,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
         BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -389,7 +389,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     int newTimeout = 1001;
     int newBatch = 2001;
 
-    Properties properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
+    LinkedHashMap properties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(initialTimeout),
         BATCH_PROPERTY, String.valueOf(initialBatch));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
@@ -401,7 +401,7 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(initialTimeout, bean.getTimeout());
     assertEquals(initialBatch, bean.getBatch());
 
-    Properties newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
+    LinkedHashMap newProperties = assembleProperties(TIMEOUT_PROPERTY, String.valueOf(newTimeout),
         BATCH_PROPERTY, String.valueOf(newBatch));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
@@ -438,18 +438,18 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     Date someNewDate = assembleDate(2018, 2, 23, 21, 2, 3, 345);
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(someDateFormat, Locale.US);
 
-    Properties properties = new Properties();
-    properties.setProperty("intProperty", String.valueOf(someInt));
-    properties.setProperty("intArrayProperty", Ints.join(", ", someIntArray));
-    properties.setProperty("longProperty", String.valueOf(someLong));
-    properties.setProperty("shortProperty", String.valueOf(someShort));
-    properties.setProperty("floatProperty", String.valueOf(someFloat));
-    properties.setProperty("doubleProperty", String.valueOf(someDouble));
-    properties.setProperty("byteProperty", String.valueOf(someByte));
-    properties.setProperty("booleanProperty", String.valueOf(someBoolean));
-    properties.setProperty("stringProperty", String.valueOf(someString));
-    properties.setProperty("dateFormat", String.valueOf(someDateFormat));
-    properties.setProperty("dateProperty", simpleDateFormat.format(someDate));
+    LinkedHashMap properties = new LinkedHashMap();
+    properties.put("intProperty", String.valueOf(someInt));
+    properties.put("intArrayProperty", Ints.join(", ", someIntArray));
+    properties.put("longProperty", String.valueOf(someLong));
+    properties.put("shortProperty", String.valueOf(someShort));
+    properties.put("floatProperty", String.valueOf(someFloat));
+    properties.put("doubleProperty", String.valueOf(someDouble));
+    properties.put("byteProperty", String.valueOf(someByte));
+    properties.put("booleanProperty", String.valueOf(someBoolean));
+    properties.put("stringProperty", String.valueOf(someString));
+    properties.put("dateFormat", String.valueOf(someDateFormat));
+    properties.put("dateProperty", simpleDateFormat.format(someDate));
 
     SimpleConfig config = prepareConfig(ConfigConsts.NAMESPACE_APPLICATION, properties);
     ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/XmlConfigPlaceholderTest10.xml");
@@ -467,18 +467,18 @@ public class XmlConfigPlaceholderAutoUpdateTest extends AbstractSpringIntegratio
     assertEquals(someString, bean.getStringProperty());
     assertEquals(someDate, bean.getDateProperty());
 
-    Properties newProperties = new Properties();
-    newProperties.setProperty("intProperty", String.valueOf(someNewInt));
-    newProperties.setProperty("intArrayProperty", Ints.join(", ", someNewIntArray));
-    newProperties.setProperty("longProperty", String.valueOf(someNewLong));
-    newProperties.setProperty("shortProperty", String.valueOf(someNewShort));
-    newProperties.setProperty("floatProperty", String.valueOf(someNewFloat));
-    newProperties.setProperty("doubleProperty", String.valueOf(someNewDouble));
-    newProperties.setProperty("byteProperty", String.valueOf(someNewByte));
-    newProperties.setProperty("booleanProperty", String.valueOf(someNewBoolean));
-    newProperties.setProperty("stringProperty", String.valueOf(someNewString));
-    newProperties.setProperty("dateFormat", String.valueOf(someDateFormat));
-    newProperties.setProperty("dateProperty", simpleDateFormat.format(someNewDate));
+    LinkedHashMap newProperties = new LinkedHashMap();
+    newProperties.put("intProperty", String.valueOf(someNewInt));
+    newProperties.put("intArrayProperty", Ints.join(", ", someNewIntArray));
+    newProperties.put("longProperty", String.valueOf(someNewLong));
+    newProperties.put("shortProperty", String.valueOf(someNewShort));
+    newProperties.put("floatProperty", String.valueOf(someNewFloat));
+    newProperties.put("doubleProperty", String.valueOf(someNewDouble));
+    newProperties.put("byteProperty", String.valueOf(someNewByte));
+    newProperties.put("booleanProperty", String.valueOf(someNewBoolean));
+    newProperties.put("stringProperty", String.valueOf(someNewString));
+    newProperties.put("dateFormat", String.valueOf(someDateFormat));
+    newProperties.put("dateProperty", simpleDateFormat.format(someNewDate));
 
     config.onRepositoryChange(ConfigConsts.NAMESPACE_APPLICATION, newProperties);
 

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/yaml/YamlParserTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/yaml/YamlParserTest.java
@@ -3,6 +3,7 @@ package com.ctrip.framework.apollo.util.yaml;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -58,7 +59,9 @@ public class YamlParserTest {
     yamlPropertiesFactoryBean.setResources(new ByteArrayResource(yamlContent.getBytes()));
     Properties expected = yamlPropertiesFactoryBean.getObject();
 
-    Properties actual = parser.yamlToProperties(yamlContent);
+    LinkedHashMap map = parser.yamlToProperties(yamlContent);
+    Properties actual =new Properties();
+    actual.putAll(map);
 
     assertTrue("expected: " + expected + " actual: " + actual, checkPropertiesEquals(expected, actual));
   }

--- a/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/PropertiesUtil.java
+++ b/apollo-core/src/main/java/com/ctrip/framework/apollo/core/utils/PropertiesUtil.java
@@ -2,6 +2,7 @@ package com.ctrip.framework.apollo.core.utils;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.LinkedHashMap;
 import java.util.Properties;
 
 /**
@@ -14,9 +15,11 @@ public class PropertiesUtil {
    * @return the string containing the properties
    * @throws IOException
    */
-  public static String toString(Properties properties) throws IOException {
+  public static String toString(LinkedHashMap properties) throws IOException {
     StringWriter writer = new StringWriter();
-    properties.store(writer, null);
+    Properties toWrite=new Properties();
+    toWrite.putAll(properties);
+    toWrite.store(writer, null);
     StringBuffer stringBuffer = writer.getBuffer();
     filterPropertiesComment(stringBuffer);
     return stringBuffer.toString();


### PR DESCRIPTION
## What's the purpose of this PR

Keep order of configuration in yml/yaml at client side. 

## Which issue(s) this PR fixes:
Fixes #2451,#2273

## Brief changelog

1. Use LinkedHashMap instead of Properties in apollo-client module.    
2. Use LinkedHashMap to keep order in DefaultConfig.java Line 112.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
