### PR TITLE
Use OrderedProperties instead of Properties

### DIFF
--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfig.java
@@ -11,6 +11,8 @@ import com.ctrip.framework.apollo.model.ConfigChangeEvent;
 import com.ctrip.framework.apollo.tracer.Tracer;
 import com.ctrip.framework.apollo.tracer.spi.Transaction;
 import com.ctrip.framework.apollo.util.ConfigUtil;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import com.ctrip.framework.apollo.util.function.Functions;
 import com.ctrip.framework.apollo.util.parser.Parsers;
 import com.google.common.base.Function;
@@ -493,11 +495,11 @@ public abstract class AbstractConfig implements Config {
   List<ConfigChange> calcPropertyChanges(String namespace, Properties previous,
                                          Properties current) {
     if (previous == null) {
-      previous = new Properties();
+      previous =  PropertiesFactory.getPropertiesObject();
     }
 
     if (current == null) {
-      current = new Properties();
+      current =  PropertiesFactory.getPropertiesObject();
     }
 
     Set<String> previousKeys = previous.stringPropertyNames();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/AbstractConfigFile.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -72,7 +74,7 @@ public abstract class AbstractConfigFile implements ConfigFile, RepositoryChange
     if (newProperties.equals(m_configProperties.get())) {
       return;
     }
-    Properties newConfigProperties = new Properties();
+    Properties newConfigProperties =  PropertiesFactory.getPropertiesObject();
     newConfigProperties.putAll(newProperties);
 
     String oldValue = getContent();

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/DefaultConfig.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -88,7 +90,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
 
     // step 4: check properties file from classpath
     if (value == null && m_resourceProperties != null) {
-      value = (String) m_resourceProperties.get(key);
+      value = (String) m_resourceProperties.getProperty(key);
     }
 
     if (value == null && m_configProperties.get() == null && m_warnLogRateLimiter.tryAcquire()) {
@@ -133,7 +135,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
     }
 
     ConfigSourceType sourceType = m_configRepository.getSourceType();
-    Properties newConfigProperties = new Properties();
+    Properties newConfigProperties =  PropertiesFactory.getPropertiesObject();
     newConfigProperties.putAll(newProperties);
 
     Map<String, ConfigChange> actualChanges = updateAndCalcConfigChanges(newConfigProperties, sourceType);
@@ -213,7 +215,7 @@ public class DefaultConfig extends AbstractConfig implements RepositoryChangeLis
     Properties properties = null;
 
     if (in != null) {
-      properties = new Properties();
+      properties =  PropertiesFactory.getPropertiesObject();
 
       try {
         properties.load(in);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/LocalFileConfigRepository.java
@@ -1,6 +1,7 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -88,7 +89,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     if (m_fileProperties == null) {
       sync();
     }
-    Properties result = new Properties();
+    Properties result =  PropertiesFactory.getPropertiesObject();
     result.putAll(m_fileProperties);
     return result;
   }
@@ -117,7 +118,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
     if (newProperties.equals(m_fileProperties)) {
       return;
     }
-    Properties newFileProperties = new Properties();
+    Properties newFileProperties =  PropertiesFactory.getPropertiesObject();
     newFileProperties.putAll(newProperties);
     updateFileProperties(newFileProperties, m_upstream.getSourceType());
     this.fireRepositoryChange(namespace, newProperties);
@@ -192,7 +193,7 @@ public class LocalFileConfigRepository extends AbstractConfigRepository
       try {
         in = new FileInputStream(file);
 
-        properties = new Properties();
+        properties =  PropertiesFactory.getPropertiesObject();
         properties.load(in);
         logger.debug("Loading local config file {} successfully!", file.getAbsolutePath());
       } catch (IOException ex) {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/RemoteConfigRepository.java
@@ -1,6 +1,7 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +159,7 @@ public class RemoteConfigRepository extends AbstractConfigRepository {
   }
 
   private Properties transformApolloConfigToProperties(ApolloConfig apolloConfig) {
-    Properties result = new Properties();
+    Properties result =  PropertiesFactory.getPropertiesObject();
     result.putAll(apolloConfig.getConfigurations());
     return result;
   }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/SimpleConfig.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/SimpleConfig.java
@@ -1,6 +1,9 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.enums.ConfigSourceType;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.OrderedProperties.OrderedPropertiesBuilder;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +84,7 @@ public class SimpleConfig extends AbstractConfig implements RepositoryChangeList
     if (newProperties.equals(m_configProperties)) {
       return;
     }
-    Properties newConfigProperties = new Properties();
+    Properties newConfigProperties = PropertiesFactory.getPropertiesObject();
     newConfigProperties.putAll(newProperties);
 
     List<ConfigChange> changes = calcPropertyChanges(namespace, m_configProperties, newConfigProperties);

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/YamlConfigFile.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/internals/YamlConfigFile.java
@@ -1,6 +1,8 @@
 package com.ctrip.framework.apollo.internals;
 
 import com.ctrip.framework.apollo.util.ExceptionUtil;
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -61,7 +63,7 @@ public class YamlConfigFile extends PlainTextConfigFile implements PropertiesCom
 
   private Properties toProperties() {
     if (!this.hasContent()) {
-      return new Properties();
+      return  PropertiesFactory.getPropertiesObject();
     }
 
     try {

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
@@ -64,21 +64,6 @@ public class OrderedProperties extends Properties {
     return (value == null) ? defaultValue : value;
   }
 
-  @Override
-  public synchronized Object get(Object key) {
-    return properties.get(key);
-  }
-
-  @Override
-  public synchronized Object put(Object key, Object value) {
-    // Make sure the value is not null
-    if (value == null) {
-      throw new NullPointerException();
-    }
-
-    // Makes sure the key is not already in the hashtable.
-    return properties.put((String)key,(String)value);
-  }
 
   /**
    * See {@link Properties#setProperty(String, String)}.
@@ -123,6 +108,48 @@ public class OrderedProperties extends Properties {
   @Override
   public boolean isEmpty() {
     return properties.isEmpty();
+  }
+
+  /**
+   * See {@link Properties#containsKey(Object)} and {@link java.util.Hashtable#containsKey(Object)}.
+   * Override to avoid invocation on Properties's containsKey.
+   */
+  @Override
+  public boolean containsKey(Object key) {
+    return properties.containsKey(key);
+  }
+
+  /**
+   * See {@link Properties#containsValue(Object)} and {@link java.util.Hashtable#containsValue(Object)}.
+   * Override to avoid invocation on Properties's containsValue.
+   */
+  @Override
+  public boolean containsValue(Object value) {
+    return properties.containsValue(value);
+  }
+
+  /**
+   * See {@link Properties#get(Object)} and {@link java.util.Hashtable#get(Object)}.
+   * Override due to invocation on Properties's get.
+   */
+  @Override
+  public synchronized Object get(Object key) {
+    return properties.get(key);
+  }
+
+  /**
+   * See {@link Properties#put(Object, Object)} and {@link java.util.Hashtable#put(Object, Object)}.
+   * Override due to invocation on Properties's put.
+   */
+  @Override
+  public synchronized Object put(Object key, Object value) {
+    // Make sure the value is not null
+    if (value == null) {
+      throw new NullPointerException();
+    }
+
+    // Makes sure the key is not already in the hashtable.
+    return properties.put((String)key,(String)value);
   }
 
   /**
@@ -303,6 +330,7 @@ public class OrderedProperties extends Properties {
    *
 
    */
+  @Override
   public synchronized void putAll(Map<? extends Object, ? extends Object> t) {
     for (Map.Entry<? extends Object, ? extends Object> e : t.entrySet()) {
       properties.put((String)e.getKey(),(String) e.getValue());

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
@@ -1,0 +1,435 @@
+package com.ctrip.framework.apollo.util;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.InvalidPropertiesFormatException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.Vector;
+
+
+public class OrderedProperties extends Properties {
+    private static final long serialVersionUID = 1L;
+
+    private transient Map<String, String> properties;
+    private transient boolean suppressDate;
+
+    /**
+     * Creates a new instance that will keep the properties in the order they have been added. Other than
+     * the ordering of the keys, this instance behaves like an instance of the {@link Properties} class.
+     */
+    public OrderedProperties() {
+        this(new LinkedHashMap<String, String>(), false);
+    }
+
+    private OrderedProperties(Map<String, String> properties, boolean suppressDate) {
+        this.properties = properties;
+        this.suppressDate = suppressDate;
+    }
+
+    /**
+     * See {@link Properties#getProperty(String)}.
+     */
+    public String getProperty(String key) {
+        return properties.get(key);
+    }
+
+    /**
+     * See {@link Properties#getProperty(String, String)}.
+     */
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        String value = properties.get(key);
+        return (value == null) ? defaultValue : value;
+    }
+
+    /**
+     * See {@link Properties#setProperty(String, String)}.
+     */
+    public String setProperty(String key, String value) {
+        return properties.put(key, value);
+    }
+
+    /**
+     * Removes the property with the specified key, if it is present. Returns
+     * the value of the property, or <tt>null</tt> if there was no property with
+     * the specified key.
+     *
+     * @param key the key of the property to remove
+     * @return the previous value of the property, or <tt>null</tt> if there was no property with the specified key
+     */
+    public String removeProperty(String key) {
+        return properties.remove(key);
+    }
+
+    /**
+     * Returns <tt>true</tt> if there is a property with the specified key.
+     *
+     * @param key the key whose presence is to be tested
+     */
+    public boolean containsProperty(String key) {
+        return properties.containsKey(key);
+    }
+
+    /**
+     * See {@link Properties#size()}.
+     */
+    public int size() {
+        return properties.size();
+    }
+
+    /**
+     * See {@link Properties#isEmpty()}.
+     */
+    public boolean isEmpty() {
+        return properties.isEmpty();
+    }
+
+    /**
+     * See {@link Properties#propertyNames()}.
+     */
+    public Enumeration<String> propertyNames() {
+        return new Vector<String>(properties.keySet()).elements();
+    }
+
+    /**
+     * See {@link Properties#stringPropertyNames()}.
+     */
+    @Override
+    public Set<String> stringPropertyNames() {
+        return new LinkedHashSet<String>(properties.keySet());
+    }
+
+    /**
+     * See {@link Properties#entrySet()}.
+     * @return
+     */
+    @Override
+    public Set<Map.Entry<Object, Object>> entrySet() {
+        return new LinkedHashSet<Map.Entry<Object, Object>>((Set) properties.entrySet());
+    }
+
+    /**
+     * See {@link Properties#load(InputStream)}.
+     */
+    public void load(InputStream stream) throws IOException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.load(stream);
+    }
+
+    /**
+     * See {@link Properties#load(Reader)}.
+     */
+    public void load(Reader reader) throws IOException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.load(reader);
+    }
+
+    /**
+     * See {@link Properties#loadFromXML(InputStream)}.
+     */
+    @SuppressWarnings("DuplicateThrows")
+    public void loadFromXML(InputStream stream) throws IOException, InvalidPropertiesFormatException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.loadFromXML(stream);
+    }
+
+    /**
+     * See {@link Properties#store(OutputStream, String)}.
+     */
+    public void store(OutputStream stream, String comments) throws IOException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        if (suppressDate) {
+            customProperties.store(new DateSuppressingPropertiesBufferedWriter(new OutputStreamWriter(stream, "8859_1")), comments);
+        } else {
+            customProperties.store(stream, comments);
+        }
+    }
+
+    /**
+     * See {@link Properties#store(Writer, String)}.
+     */
+    public void store(Writer writer, String comments) throws IOException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        if (suppressDate) {
+            customProperties.store(new DateSuppressingPropertiesBufferedWriter(writer), comments);
+        } else {
+            customProperties.store(writer, comments);
+        }
+    }
+
+    /**
+     * See {@link Properties#storeToXML(OutputStream, String)}.
+     */
+    public void storeToXML(OutputStream stream, String comment) throws IOException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.storeToXML(stream, comment);
+    }
+
+    /**
+     * See {@link Properties#storeToXML(OutputStream, String, String)}.
+     */
+    public void storeToXML(OutputStream stream, String comment, String encoding) throws IOException {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.storeToXML(stream, comment, encoding);
+    }
+
+    /**
+     * See {@link Properties#list(PrintStream)}.
+     */
+    public void list(PrintStream stream) {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.list(stream);
+    }
+
+    /**
+     * See {@link Properties#list(PrintWriter)}.
+     */
+    public void list(PrintWriter writer) {
+        CustomProperties customProperties = new CustomProperties(this.properties);
+        customProperties.list(writer);
+    }
+
+    /**
+     * Convert this instance to a {@link Properties} instance.
+     *
+     * @return the {@link Properties} instance
+     */
+    public Properties toJdkProperties() {
+        Properties jdkProperties = new Properties();
+        for (Map.Entry<Object, Object> entry : this.entrySet()) {
+            jdkProperties.put(entry.getKey(), entry.getValue());
+        }
+        return jdkProperties;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+
+        OrderedProperties that = (OrderedProperties) other;
+        return Arrays.equals(properties.entrySet().toArray(), that.properties.entrySet().toArray());
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(properties.entrySet().toArray());
+    }
+
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        stream.defaultWriteObject();
+        stream.writeObject(properties);
+        stream.writeBoolean(suppressDate);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        properties = (Map<String, String>) stream.readObject();
+        suppressDate = stream.readBoolean();
+    }
+
+    private void readObjectNoData() throws InvalidObjectException {
+        throw new InvalidObjectException("Stream data required");
+    }
+
+    /**
+     * See {@link Properties#toString()}.
+     */
+    @Override
+    public String toString() {
+        return properties.toString();
+    }
+
+    /**
+     * Copies all of the mappings from the specified map to this hashtable.
+     * These mappings will replace any mappings that this hashtable had for any
+     * of the keys currently in the specified map.
+     *
+
+     */
+    public synchronized void putAll(Map<? extends Object, ? extends Object> t) {
+        for (Map.Entry<? extends Object, ? extends Object> e : t.entrySet()) {
+            properties.put((String)e.getKey(),(String) e.getValue());
+        }
+    }
+
+    /**
+     * Creates a new instance that will have both the same property entries and
+     * the same behavior as the given source.
+     * <p/>
+     * Note that the source instance and the copy instance will share the same
+     * comparator instance if a custom ordering had been configured on the source.
+     *
+     * @param source the source to copy from
+     * @return the copy
+     */
+    public static OrderedProperties copyOf(OrderedProperties source) {
+        // create a copy that has the same behaviour
+        OrderedPropertiesBuilder builder = new OrderedPropertiesBuilder();
+        builder.withSuppressDateInComment(source.suppressDate);
+        if (source.properties instanceof TreeMap) {
+            builder.withOrdering(((TreeMap<String, String>) source.properties).comparator());
+        }
+        OrderedProperties result = builder.build();
+
+        // copy the properties from the source to the target
+        for (Map.Entry<Object, Object> entry : source.entrySet()) {
+            result.setProperty((String)entry.getKey(), (String)entry.getValue());
+        }
+        return result;
+    }
+
+    /**
+     * Builder for {@link OrderedProperties} instances.
+     */
+    public static final class OrderedPropertiesBuilder {
+
+        private Comparator<? super String> comparator;
+        private boolean suppressDate;
+
+        /**
+         * Use a custom ordering of the keys.
+         *
+         * @param comparator the ordering to apply on the keys
+         * @return the builder
+         */
+        public OrderedPropertiesBuilder withOrdering(Comparator<? super String> comparator) {
+            this.comparator = comparator;
+            return this;
+        }
+
+        /**
+         * Suppress the comment that contains the current date when storing the properties.
+         *
+         * @param suppressDate whether to suppress the comment that contains the current date
+         * @return the builder
+         */
+        public OrderedPropertiesBuilder withSuppressDateInComment(boolean suppressDate) {
+            this.suppressDate = suppressDate;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link OrderedProperties} instance.
+         *
+         * @return the new instance
+         */
+        public OrderedProperties build() {
+            Map<String, String> properties = (this.comparator != null) ?
+                    new TreeMap<String, String>(comparator) :
+                    new LinkedHashMap<String, String>();
+            return new OrderedProperties(properties, suppressDate);
+        }
+
+    }
+
+    /**
+     * Custom {@link Properties} that delegates reading, writing, and enumerating properties to the
+     * backing {@link OrderedProperties} instance's properties.
+     */
+    private static final class CustomProperties extends Properties {
+
+        private final Map<String, String> targetProperties;
+
+        private CustomProperties(Map<String, String> targetProperties) {
+            this.targetProperties = targetProperties;
+        }
+
+        @Override
+        public Object get(Object key) {
+            return targetProperties.get(key);
+        }
+
+        @Override
+        public Object put(Object key, Object value) {
+            return targetProperties.put((String) key, (String) value);
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return targetProperties.get(key);
+        }
+
+        @Override
+        public Enumeration<Object> keys() {
+            return new Vector<Object>(targetProperties.keySet()).elements();
+        }
+
+        @SuppressWarnings("NullableProblems")
+        @Override
+        public Set<Object> keySet() {
+            return new LinkedHashSet<Object>(targetProperties.keySet());
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Set<Map.Entry<Object, Object>> entrySet() {
+            Set entrySet = targetProperties.entrySet();
+            return (Set<Map.Entry<Object, Object>>) entrySet;
+        }
+
+    }
+
+    /**
+     * Custom {@link BufferedWriter} for storing properties that will write all leading lines of comments except
+     * the last comment line. Using the JDK Properties class to store properties, the last comment
+     * line always contains the current date which is what we want to filter out.
+     */
+    private static final class DateSuppressingPropertiesBufferedWriter extends BufferedWriter {
+
+        private final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+        private StringBuilder currentComment;
+        private String previousComment;
+
+        private DateSuppressingPropertiesBufferedWriter(Writer out) {
+            super(out);
+        }
+
+        @SuppressWarnings("NullableProblems")
+        @Override
+        public void write(String string) throws IOException {
+            if (currentComment != null) {
+                currentComment.append(string);
+                if (string.endsWith(LINE_SEPARATOR)) {
+                    if (previousComment != null) {
+                        super.write(previousComment);
+                    }
+
+                    previousComment = currentComment.toString();
+                    currentComment = null;
+                }
+            } else if (string.startsWith("#")) {
+                currentComment = new StringBuilder(string);
+            } else {
+                super.write(string);
+            }
+        }
+
+    }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
@@ -14,6 +14,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.InvalidPropertiesFormatException;
@@ -307,6 +308,12 @@ public class OrderedProperties extends Properties {
       properties.put((String)e.getKey(),(String) e.getValue());
     }
   }
+
+  @Override
+  public Set<Object> keySet() {
+    return (Set)properties.keySet();
+  }
+
 
   /**
    * Creates a new instance that will have both the same property entries and

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/OrderedProperties.java
@@ -27,409 +27,439 @@ import java.util.Vector;
 
 
 public class OrderedProperties extends Properties {
-    private static final long serialVersionUID = 1L;
 
-    private transient Map<String, String> properties;
-    private transient boolean suppressDate;
+  private static final long serialVersionUID = -5958921339581782524L;
 
-    /**
-     * Creates a new instance that will keep the properties in the order they have been added. Other than
-     * the ordering of the keys, this instance behaves like an instance of the {@link Properties} class.
-     */
-    public OrderedProperties() {
-        this(new LinkedHashMap<String, String>(), false);
+  private transient Map<String, String> properties;
+  private transient boolean suppressDate;
+
+  /**
+   * Creates a new instance that will keep the properties in the order they have been added. Other than
+   * the ordering of the keys, this instance behaves like an instance of the {@link Properties} class.
+   */
+  public OrderedProperties() {
+    this(new LinkedHashMap<String, String>(), false);
+  }
+
+  private OrderedProperties(Map<String, String> properties, boolean suppressDate) {
+    this.properties = properties;
+    this.suppressDate = suppressDate;
+  }
+
+  /**
+   * See {@link Properties#getProperty(String)}.
+   */
+  @Override
+  public String getProperty(String key) {
+    return properties.get(key);
+  }
+
+  /**
+   * See {@link Properties#getProperty(String, String)}.
+   */
+  @Override
+  public String getProperty(String key, String defaultValue) {
+    String value = properties.get(key);
+    return (value == null) ? defaultValue : value;
+  }
+
+  @Override
+  public synchronized Object get(Object key) {
+    return properties.get(key);
+  }
+
+  @Override
+  public synchronized Object put(Object key, Object value) {
+    // Make sure the value is not null
+    if (value == null) {
+      throw new NullPointerException();
     }
 
-    private OrderedProperties(Map<String, String> properties, boolean suppressDate) {
-        this.properties = properties;
-        this.suppressDate = suppressDate;
+    // Makes sure the key is not already in the hashtable.
+    return properties.put((String)key,(String)value);
+  }
+
+  /**
+   * See {@link Properties#setProperty(String, String)}.
+   */
+  @Override
+  public String setProperty(String key, String value) {
+    return properties.put(key, value);
+  }
+
+  /**
+   * Removes the property with the specified key, if it is present. Returns
+   * the value of the property, or <tt>null</tt> if there was no property with
+   * the specified key.
+   *
+   * @param key the key of the property to remove
+   * @return the previous value of the property, or <tt>null</tt> if there was no property with the specified key
+   */
+  public String removeProperty(String key) {
+    return properties.remove(key);
+  }
+
+  /**
+   * Returns <tt>true</tt> if there is a property with the specified key.
+   *
+   * @param key the key whose presence is to be tested
+   */
+  public boolean containsProperty(String key) {
+    return properties.containsKey(key);
+  }
+
+  /**
+   * See {@link Properties#size()}.
+   */
+  @Override
+  public int size() {
+    return properties.size();
+  }
+
+  /**
+   * See {@link Properties#isEmpty()}.
+   */
+  @Override
+  public boolean isEmpty() {
+    return properties.isEmpty();
+  }
+
+  /**
+   * See {@link Properties#propertyNames()}.
+   */
+  @Override
+  public Enumeration<String> propertyNames() {
+    return new Vector<String>(properties.keySet()).elements();
+  }
+
+  /**
+   * See {@link Properties#stringPropertyNames()}.
+   */
+  @Override
+  public Set<String> stringPropertyNames() {
+    return new LinkedHashSet<String>(properties.keySet());
+  }
+
+  /**
+   * See {@link Properties#entrySet()}.
+   * @return
+   */
+  @Override
+  public Set<Map.Entry<Object, Object>> entrySet() {
+    return new LinkedHashSet<Map.Entry<Object, Object>>((Set) properties.entrySet());
+  }
+
+  /**
+   * See {@link Properties#load(InputStream)}.
+   */
+  public void load(InputStream stream) throws IOException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.load(stream);
+  }
+
+  /**
+   * See {@link Properties#load(Reader)}.
+   */
+  @Override
+  public void load(Reader reader) throws IOException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.load(reader);
+  }
+
+  /**
+   * See {@link Properties#loadFromXML(InputStream)}.
+   */
+  @SuppressWarnings("DuplicateThrows")
+  @Override
+  public void loadFromXML(InputStream stream) throws IOException, InvalidPropertiesFormatException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.loadFromXML(stream);
+  }
+
+  /**
+   * See {@link Properties#store(OutputStream, String)}.
+   */
+  @Override
+  public void store(OutputStream stream, String comments) throws IOException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    if (suppressDate) {
+      customProperties.store(new DateSuppressingPropertiesBufferedWriter(new OutputStreamWriter(stream, "8859_1")), comments);
+    } else {
+      customProperties.store(stream, comments);
+    }
+  }
+
+  /**
+   * See {@link Properties#store(Writer, String)}.
+   */
+  @Override
+  public void store(Writer writer, String comments) throws IOException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    if (suppressDate) {
+      customProperties.store(new DateSuppressingPropertiesBufferedWriter(writer), comments);
+    } else {
+      customProperties.store(writer, comments);
+    }
+  }
+
+  /**
+   * See {@link Properties#storeToXML(OutputStream, String)}.
+   */
+  @Override
+  public void storeToXML(OutputStream stream, String comment) throws IOException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.storeToXML(stream, comment);
+  }
+
+  /**
+   * See {@link Properties#storeToXML(OutputStream, String, String)}.
+   */
+  @Override
+  public void storeToXML(OutputStream stream, String comment, String encoding) throws IOException {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.storeToXML(stream, comment, encoding);
+  }
+
+  /**
+   * See {@link Properties#list(PrintStream)}.
+   */
+  @Override
+  public void list(PrintStream stream) {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.list(stream);
+  }
+
+  /**
+   * See {@link Properties#list(PrintWriter)}.
+   */
+  @Override
+  public void list(PrintWriter writer) {
+    CustomProperties customProperties = new CustomProperties(this.properties);
+    customProperties.list(writer);
+  }
+
+  /**
+   * Convert this instance to a {@link Properties} instance.
+   *
+   * @return the {@link Properties} instance
+   */
+  public Properties toJdkProperties() {
+    Properties jdkProperties = new Properties();
+    for (Map.Entry<Object, Object> entry : this.entrySet()) {
+      jdkProperties.put(entry.getKey(), entry.getValue());
+    }
+    return jdkProperties;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    OrderedProperties that = (OrderedProperties) other;
+    return Arrays.equals(properties.entrySet().toArray(), that.properties.entrySet().toArray());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(properties.entrySet().toArray());
+  }
+
+  private void writeObject(ObjectOutputStream stream) throws IOException {
+    stream.defaultWriteObject();
+    stream.writeObject(properties);
+    stream.writeBoolean(suppressDate);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+    stream.defaultReadObject();
+    properties = (Map<String, String>) stream.readObject();
+    suppressDate = stream.readBoolean();
+  }
+
+  private void readObjectNoData() throws InvalidObjectException {
+    throw new InvalidObjectException("Stream data required");
+  }
+
+  /**
+   * See {@link Properties#toString()}.
+   */
+  @Override
+  public String toString() {
+    return properties.toString();
+  }
+
+  /**
+   * Copies all of the mappings from the specified map to this hashtable.
+   * These mappings will replace any mappings that this hashtable had for any
+   * of the keys currently in the specified map.
+   *
+
+   */
+  public synchronized void putAll(Map<? extends Object, ? extends Object> t) {
+    for (Map.Entry<? extends Object, ? extends Object> e : t.entrySet()) {
+      properties.put((String)e.getKey(),(String) e.getValue());
+    }
+  }
+
+  /**
+   * Creates a new instance that will have both the same property entries and
+   * the same behavior as the given source.
+   * <p/>
+   * Note that the source instance and the copy instance will share the same
+   * comparator instance if a custom ordering had been configured on the source.
+   *
+   * @param source the source to copy from
+   * @return the copy
+   */
+  public static OrderedProperties copyOf(OrderedProperties source) {
+    // create a copy that has the same behaviour
+    OrderedPropertiesBuilder builder = new OrderedPropertiesBuilder();
+    builder.withSuppressDateInComment(source.suppressDate);
+    if (source.properties instanceof TreeMap) {
+      builder.withOrdering(((TreeMap<String, String>) source.properties).comparator());
+    }
+    OrderedProperties result = builder.build();
+
+    // copy the properties from the source to the target
+    for (Map.Entry<Object, Object> entry : source.entrySet()) {
+      result.setProperty((String)entry.getKey(), (String)entry.getValue());
+    }
+    return result;
+  }
+
+  /**
+   * Builder for {@link OrderedProperties} instances.
+   */
+  public static final class OrderedPropertiesBuilder {
+
+    private Comparator<? super String> comparator;
+    private boolean suppressDate;
+
+    /**
+     * Use a custom ordering of the keys.
+     *
+     * @param comparator the ordering to apply on the keys
+     * @return the builder
+     */
+    public OrderedPropertiesBuilder withOrdering(Comparator<? super String> comparator) {
+      this.comparator = comparator;
+      return this;
     }
 
     /**
-     * See {@link Properties#getProperty(String)}.
+     * Suppress the comment that contains the current date when storing the properties.
+     *
+     * @param suppressDate whether to suppress the comment that contains the current date
+     * @return the builder
      */
+    public OrderedPropertiesBuilder withSuppressDateInComment(boolean suppressDate) {
+      this.suppressDate = suppressDate;
+      return this;
+    }
+
+    /**
+     * Builds a new {@link OrderedProperties} instance.
+     *
+     * @return the new instance
+     */
+    public OrderedProperties build() {
+      Map<String, String> properties = (this.comparator != null) ?
+          new TreeMap<String, String>(comparator) :
+          new LinkedHashMap<String, String>();
+      return new OrderedProperties(properties, suppressDate);
+    }
+
+  }
+
+  /**
+   * Custom {@link Properties} that delegates reading, writing, and enumerating properties to the
+   * backing {@link OrderedProperties} instance's properties.
+   */
+  private static final class CustomProperties extends Properties {
+
+    private final Map<String, String> targetProperties;
+
+    private CustomProperties(Map<String, String> targetProperties) {
+      this.targetProperties = targetProperties;
+    }
+
+    @Override
+    public Object get(Object key) {
+      return targetProperties.get(key);
+    }
+
+    @Override
+    public Object put(Object key, Object value) {
+      return targetProperties.put((String) key, (String) value);
+    }
+
+    @Override
     public String getProperty(String key) {
-        return properties.get(key);
-    }
-
-    /**
-     * See {@link Properties#getProperty(String, String)}.
-     */
-    @Override
-    public String getProperty(String key, String defaultValue) {
-        String value = properties.get(key);
-        return (value == null) ? defaultValue : value;
-    }
-
-    /**
-     * See {@link Properties#setProperty(String, String)}.
-     */
-    public String setProperty(String key, String value) {
-        return properties.put(key, value);
-    }
-
-    /**
-     * Removes the property with the specified key, if it is present. Returns
-     * the value of the property, or <tt>null</tt> if there was no property with
-     * the specified key.
-     *
-     * @param key the key of the property to remove
-     * @return the previous value of the property, or <tt>null</tt> if there was no property with the specified key
-     */
-    public String removeProperty(String key) {
-        return properties.remove(key);
-    }
-
-    /**
-     * Returns <tt>true</tt> if there is a property with the specified key.
-     *
-     * @param key the key whose presence is to be tested
-     */
-    public boolean containsProperty(String key) {
-        return properties.containsKey(key);
-    }
-
-    /**
-     * See {@link Properties#size()}.
-     */
-    public int size() {
-        return properties.size();
-    }
-
-    /**
-     * See {@link Properties#isEmpty()}.
-     */
-    public boolean isEmpty() {
-        return properties.isEmpty();
-    }
-
-    /**
-     * See {@link Properties#propertyNames()}.
-     */
-    public Enumeration<String> propertyNames() {
-        return new Vector<String>(properties.keySet()).elements();
-    }
-
-    /**
-     * See {@link Properties#stringPropertyNames()}.
-     */
-    @Override
-    public Set<String> stringPropertyNames() {
-        return new LinkedHashSet<String>(properties.keySet());
-    }
-
-    /**
-     * See {@link Properties#entrySet()}.
-     * @return
-     */
-    @Override
-    public Set<Map.Entry<Object, Object>> entrySet() {
-        return new LinkedHashSet<Map.Entry<Object, Object>>((Set) properties.entrySet());
-    }
-
-    /**
-     * See {@link Properties#load(InputStream)}.
-     */
-    public void load(InputStream stream) throws IOException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.load(stream);
-    }
-
-    /**
-     * See {@link Properties#load(Reader)}.
-     */
-    public void load(Reader reader) throws IOException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.load(reader);
-    }
-
-    /**
-     * See {@link Properties#loadFromXML(InputStream)}.
-     */
-    @SuppressWarnings("DuplicateThrows")
-    public void loadFromXML(InputStream stream) throws IOException, InvalidPropertiesFormatException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.loadFromXML(stream);
-    }
-
-    /**
-     * See {@link Properties#store(OutputStream, String)}.
-     */
-    public void store(OutputStream stream, String comments) throws IOException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        if (suppressDate) {
-            customProperties.store(new DateSuppressingPropertiesBufferedWriter(new OutputStreamWriter(stream, "8859_1")), comments);
-        } else {
-            customProperties.store(stream, comments);
-        }
-    }
-
-    /**
-     * See {@link Properties#store(Writer, String)}.
-     */
-    public void store(Writer writer, String comments) throws IOException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        if (suppressDate) {
-            customProperties.store(new DateSuppressingPropertiesBufferedWriter(writer), comments);
-        } else {
-            customProperties.store(writer, comments);
-        }
-    }
-
-    /**
-     * See {@link Properties#storeToXML(OutputStream, String)}.
-     */
-    public void storeToXML(OutputStream stream, String comment) throws IOException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.storeToXML(stream, comment);
-    }
-
-    /**
-     * See {@link Properties#storeToXML(OutputStream, String, String)}.
-     */
-    public void storeToXML(OutputStream stream, String comment, String encoding) throws IOException {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.storeToXML(stream, comment, encoding);
-    }
-
-    /**
-     * See {@link Properties#list(PrintStream)}.
-     */
-    public void list(PrintStream stream) {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.list(stream);
-    }
-
-    /**
-     * See {@link Properties#list(PrintWriter)}.
-     */
-    public void list(PrintWriter writer) {
-        CustomProperties customProperties = new CustomProperties(this.properties);
-        customProperties.list(writer);
-    }
-
-    /**
-     * Convert this instance to a {@link Properties} instance.
-     *
-     * @return the {@link Properties} instance
-     */
-    public Properties toJdkProperties() {
-        Properties jdkProperties = new Properties();
-        for (Map.Entry<Object, Object> entry : this.entrySet()) {
-            jdkProperties.put(entry.getKey(), entry.getValue());
-        }
-        return jdkProperties;
+      return targetProperties.get(key);
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-
-        if (other == null || getClass() != other.getClass()) {
-            return false;
-        }
-
-        OrderedProperties that = (OrderedProperties) other;
-        return Arrays.equals(properties.entrySet().toArray(), that.properties.entrySet().toArray());
+    public Enumeration<Object> keys() {
+      return new Vector<Object>(targetProperties.keySet()).elements();
     }
 
+    @SuppressWarnings("NullableProblems")
     @Override
-    public int hashCode() {
-        return Arrays.hashCode(properties.entrySet().toArray());
-    }
-
-    private void writeObject(ObjectOutputStream stream) throws IOException {
-        stream.defaultWriteObject();
-        stream.writeObject(properties);
-        stream.writeBoolean(suppressDate);
+    public Set<Object> keySet() {
+      return new LinkedHashSet<Object>(targetProperties.keySet());
     }
 
     @SuppressWarnings("unchecked")
-    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
-        stream.defaultReadObject();
-        properties = (Map<String, String>) stream.readObject();
-        suppressDate = stream.readBoolean();
-    }
-
-    private void readObjectNoData() throws InvalidObjectException {
-        throw new InvalidObjectException("Stream data required");
-    }
-
-    /**
-     * See {@link Properties#toString()}.
-     */
     @Override
-    public String toString() {
-        return properties.toString();
+    public Set<Map.Entry<Object, Object>> entrySet() {
+      Set entrySet = targetProperties.entrySet();
+      return (Set<Map.Entry<Object, Object>>) entrySet;
     }
 
-    /**
-     * Copies all of the mappings from the specified map to this hashtable.
-     * These mappings will replace any mappings that this hashtable had for any
-     * of the keys currently in the specified map.
-     *
+  }
 
-     */
-    public synchronized void putAll(Map<? extends Object, ? extends Object> t) {
-        for (Map.Entry<? extends Object, ? extends Object> e : t.entrySet()) {
-            properties.put((String)e.getKey(),(String) e.getValue());
-        }
+  /**
+   * Custom {@link BufferedWriter} for storing properties that will write all leading lines of comments except
+   * the last comment line. Using the JDK Properties class to store properties, the last comment
+   * line always contains the current date which is what we want to filter out.
+   */
+  private static final class DateSuppressingPropertiesBufferedWriter extends BufferedWriter {
+
+    private final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+    private StringBuilder currentComment;
+    private String previousComment;
+
+    private DateSuppressingPropertiesBufferedWriter(Writer out) {
+      super(out);
     }
 
-    /**
-     * Creates a new instance that will have both the same property entries and
-     * the same behavior as the given source.
-     * <p/>
-     * Note that the source instance and the copy instance will share the same
-     * comparator instance if a custom ordering had been configured on the source.
-     *
-     * @param source the source to copy from
-     * @return the copy
-     */
-    public static OrderedProperties copyOf(OrderedProperties source) {
-        // create a copy that has the same behaviour
-        OrderedPropertiesBuilder builder = new OrderedPropertiesBuilder();
-        builder.withSuppressDateInComment(source.suppressDate);
-        if (source.properties instanceof TreeMap) {
-            builder.withOrdering(((TreeMap<String, String>) source.properties).comparator());
-        }
-        OrderedProperties result = builder.build();
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public void write(String string) throws IOException {
+      if (currentComment != null) {
+        currentComment.append(string);
+        if (string.endsWith(LINE_SEPARATOR)) {
+          if (previousComment != null) {
+            super.write(previousComment);
+          }
 
-        // copy the properties from the source to the target
-        for (Map.Entry<Object, Object> entry : source.entrySet()) {
-            result.setProperty((String)entry.getKey(), (String)entry.getValue());
+          previousComment = currentComment.toString();
+          currentComment = null;
         }
-        return result;
+      } else if (string.startsWith("#")) {
+        currentComment = new StringBuilder(string);
+      } else {
+        super.write(string);
+      }
     }
 
-    /**
-     * Builder for {@link OrderedProperties} instances.
-     */
-    public static final class OrderedPropertiesBuilder {
-
-        private Comparator<? super String> comparator;
-        private boolean suppressDate;
-
-        /**
-         * Use a custom ordering of the keys.
-         *
-         * @param comparator the ordering to apply on the keys
-         * @return the builder
-         */
-        public OrderedPropertiesBuilder withOrdering(Comparator<? super String> comparator) {
-            this.comparator = comparator;
-            return this;
-        }
-
-        /**
-         * Suppress the comment that contains the current date when storing the properties.
-         *
-         * @param suppressDate whether to suppress the comment that contains the current date
-         * @return the builder
-         */
-        public OrderedPropertiesBuilder withSuppressDateInComment(boolean suppressDate) {
-            this.suppressDate = suppressDate;
-            return this;
-        }
-
-        /**
-         * Builds a new {@link OrderedProperties} instance.
-         *
-         * @return the new instance
-         */
-        public OrderedProperties build() {
-            Map<String, String> properties = (this.comparator != null) ?
-                    new TreeMap<String, String>(comparator) :
-                    new LinkedHashMap<String, String>();
-            return new OrderedProperties(properties, suppressDate);
-        }
-
-    }
-
-    /**
-     * Custom {@link Properties} that delegates reading, writing, and enumerating properties to the
-     * backing {@link OrderedProperties} instance's properties.
-     */
-    private static final class CustomProperties extends Properties {
-
-        private final Map<String, String> targetProperties;
-
-        private CustomProperties(Map<String, String> targetProperties) {
-            this.targetProperties = targetProperties;
-        }
-
-        @Override
-        public Object get(Object key) {
-            return targetProperties.get(key);
-        }
-
-        @Override
-        public Object put(Object key, Object value) {
-            return targetProperties.put((String) key, (String) value);
-        }
-
-        @Override
-        public String getProperty(String key) {
-            return targetProperties.get(key);
-        }
-
-        @Override
-        public Enumeration<Object> keys() {
-            return new Vector<Object>(targetProperties.keySet()).elements();
-        }
-
-        @SuppressWarnings("NullableProblems")
-        @Override
-        public Set<Object> keySet() {
-            return new LinkedHashSet<Object>(targetProperties.keySet());
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Set<Map.Entry<Object, Object>> entrySet() {
-            Set entrySet = targetProperties.entrySet();
-            return (Set<Map.Entry<Object, Object>>) entrySet;
-        }
-
-    }
-
-    /**
-     * Custom {@link BufferedWriter} for storing properties that will write all leading lines of comments except
-     * the last comment line. Using the JDK Properties class to store properties, the last comment
-     * line always contains the current date which is what we want to filter out.
-     */
-    private static final class DateSuppressingPropertiesBufferedWriter extends BufferedWriter {
-
-        private final String LINE_SEPARATOR = System.getProperty("line.separator");
-
-        private StringBuilder currentComment;
-        private String previousComment;
-
-        private DateSuppressingPropertiesBufferedWriter(Writer out) {
-            super(out);
-        }
-
-        @SuppressWarnings("NullableProblems")
-        @Override
-        public void write(String string) throws IOException {
-            if (currentComment != null) {
-                currentComment.append(string);
-                if (string.endsWith(LINE_SEPARATOR)) {
-                    if (previousComment != null) {
-                        super.write(previousComment);
-                    }
-
-                    previousComment = currentComment.toString();
-                    currentComment = null;
-                }
-            } else if (string.startsWith("#")) {
-                currentComment = new StringBuilder(string);
-            } else {
-                super.write(string);
-            }
-        }
-
-    }
+  }
 }

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/PropertiesFactory.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/factory/PropertiesFactory.java
@@ -1,0 +1,11 @@
+package com.ctrip.framework.apollo.util.factory;
+
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import java.util.Properties;
+
+public class PropertiesFactory {
+
+  public static Properties getPropertiesObject(){
+    return new OrderedProperties();
+  }
+}

--- a/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
+++ b/apollo-client/src/main/java/com/ctrip/framework/apollo/util/yaml/YamlParser.java
@@ -1,5 +1,7 @@
 package com.ctrip.framework.apollo.util.yaml;
 
+import com.ctrip.framework.apollo.util.OrderedProperties;
+import com.ctrip.framework.apollo.util.factory.PropertiesFactory;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,7 +32,7 @@ public class YamlParser {
    */
   public Properties yamlToProperties(String yamlContent) {
     Yaml yaml = createYaml();
-    final Properties result = new Properties();
+    final Properties result = PropertiesFactory.getPropertiesObject();
     process(new MatchCallback() {
       @Override
       public void process(Properties properties, Map<String, Object> map) {
@@ -91,7 +93,7 @@ public class YamlParser {
   }
 
   private boolean process(Map<String, Object> map, MatchCallback callback) {
-    Properties properties = new Properties();
+    Properties properties = PropertiesFactory.getPropertiesObject();
     properties.putAll(getFlattenedMap(map));
 
     if (logger.isDebugEnabled()) {

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -105,7 +105,8 @@ public class RemoteConfigRepositoryTest {
 
     Properties config = remoteConfigRepository.getConfig();
 
-    assertEquals(configurations, config);
+//    assertEquals(configurations, config);
+    assertTrue(configurations.equals(config));
     assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
     remoteConfigLongPollService.stopLongPollingRefresh();
   }

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/RemoteConfigRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.ctrip.framework.apollo.internals;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -94,8 +95,9 @@ public class RemoteConfigRepositoryTest {
   public void testLoadConfig() throws Exception {
     String someKey = "someKey";
     String someValue = "someValue";
-    Map<String, String> configurations = Maps.newHashMap();
+    Map<String, String> configurations = Maps.newLinkedHashMap();
     configurations.put(someKey, someValue);
+    configurations.put("someKey2", "someValue2");
     ApolloConfig someApolloConfig = assembleApolloConfig(configurations);
 
     when(someResponse.getStatusCode()).thenReturn(200);
@@ -109,6 +111,10 @@ public class RemoteConfigRepositoryTest {
     assertTrue(configurations.equals(config));
     assertEquals(ConfigSourceType.REMOTE, remoteConfigRepository.getSourceType());
     remoteConfigLongPollService.stopLongPollingRefresh();
+
+    String[] actualArrays = config.keySet().toArray(new String[]{});
+    String[] expectedArrays={"someKey","someKey2"};
+    assertArrayEquals(expectedArrays,actualArrays);
   }
 
   @Test(expected = ApolloConfigException.class)

--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/YamlConfigFileTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/internals/YamlConfigFileTest.java
@@ -55,6 +55,34 @@ public class YamlConfigFileTest {
   }
 
   @Test
+  public void testWhenHasContentWithOrder() throws Exception {
+    Properties someProperties = new Properties();
+    String key = ConfigConsts.CONFIG_FILE_CONTENT_KEY;
+    String someContent = "someKey: 'someValue'\nsomeKey2: 'someValue2'";
+    someProperties.setProperty(key, someContent);
+    someSourceType = ConfigSourceType.LOCAL;
+
+//    Properties yamlProperties = new Properties();
+//    yamlProperties.setProperty("someKey", "someValue");
+//    yamlProperties.setProperty("someKey2", "someValue2");
+
+    Properties yamlProperties=new YamlParser().yamlToProperties(someContent);
+
+    when(configRepository.getConfig()).thenReturn(someProperties);
+    when(configRepository.getSourceType()).thenReturn(someSourceType);
+    when(yamlParser.yamlToProperties(someContent)).thenReturn(yamlProperties);
+
+    YamlConfigFile configFile = new YamlConfigFile(someNamespace, configRepository);
+
+    assertSame(someContent, configFile.getContent());
+    assertSame(yamlProperties, configFile.asProperties());
+
+    String[] actualArrays = configFile.asProperties().keySet().toArray(new String[]{});
+    String[] expectedArrays={"someKey","someKey2"};
+    assertArrayEquals(expectedArrays,actualArrays);
+  }
+
+  @Test
   public void testWhenHasNoContent() throws Exception {
     when(configRepository.getConfig()).thenReturn(null);
 


### PR DESCRIPTION
## What's the purpose of this PR

Keep order of configuration in yml/yaml at client side. This feature is implemented by improved  [OrderedProperties.java](https://github.com/etiennestuder/java-ordered-properties/blob/master/src/main/java/nu/studer/java/util/OrderedProperties.java).

## Which issue(s) this PR fixes:
Fixes #2451, #2273

## Brief changelog

1. Extend OrderedProperties from Properties, and implemented get/put/putAll from Hashtable.
2. Use LinkedHashMap instead of Properties in apollo-client module.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Read the [Contributing Guide](https://github.com/ctripcorp/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit tests to verify the code.
- [x] Run `mvn clean test` to make sure this pull request doesn't break anything.
