### PR TITLE
remove elements test case in OrderedProperty, because it is not requi…

### DIFF
--- a/apollo-client/src/test/java/com/ctrip/framework/apollo/util/OrderedPropertiesTest.java
+++ b/apollo-client/src/test/java/com/ctrip/framework/apollo/util/OrderedPropertiesTest.java
@@ -57,18 +57,6 @@ public class OrderedPropertiesTest {
   }
 
   @Test
-  public void testElements(){
-    Enumeration<Object> values = orderedProperties.elements();
-    assertTrue(values.hasMoreElements());
-    String value1= (String) values.nextElement();
-    assertEquals("value1",value1);
-    assertTrue(values.hasMoreElements());
-    String value2= (String) values.nextElement();
-    assertEquals("value2",value2);
-
-  }
-
-  @Test
   public void testRemove(){
     Object value1 = orderedProperties.remove("key1");
     assertEquals("value1",value1);


### PR DESCRIPTION
remove elements test case in OrderedProperty, because it is not required to keep values order as same as keys
